### PR TITLE
fix: Move url_launcher to dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -563,7 +563,7 @@ packages:
     source: hosted
     version: "1.3.2"
   url_launcher:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: eb1e00ab44303d50dd487aab67ebc575456c146c6af44422f9c13889984c00f3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     sdk: flutter
   http: ^1.0.0
   transparent_image: ^2.0.1
+  url_launcher: ^6.1.11
 
 dev_dependencies:
   build_runner:
@@ -27,7 +28,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  url_launcher: ^6.1.11
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
アプリケーションコードで `url_launcher` が使われていたため、 `dependencies` に移動しました。

使用箇所： `lib/core/sections/staff.dart`