### PR TITLE
GitHub Actions の Auto Format の並列実行される job の個数を制限

### DIFF
--- a/.github/workflows/auto-format.yaml
+++ b/.github/workflows/auto-format.yaml
@@ -26,11 +26,15 @@ jobs:
         run: |
           files=$(find lib test -name "*.dart" -not \( -name "*.*freezed.dart" -o -name "*.*g.dart" -o -name "*.gen.dart" \))
           for file in $files; do
+            # limit jobs to 5
+            if [ "$(jobs -r | wc -l)" -ge 5 ]; then
+              wait "$(jobs -r -p | head -1)"
+            fi
             dart fix --apply "$file" &
           done
           wait
 
-          dart format $files
+          dart format "$files"
 
       # 変更が発生した場合は プルリクエストを作成
       - name: Create pull request


### PR DESCRIPTION
## Issue

- close #64　

## Overview (Required)

並列実行される job の個数を制限して、

## Links

- https://stackoverflow.com/questions/49823080/use-bash-wait-in-for-loop

## Screenshot

実行されればわかるため省略
