### PR TITLE
Google Analytics 4 を導入

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,15 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
+  <!-- Google Analytics 4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7J6Q968NBL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-7J6Q968NBL');
+  </script>
+
   <title>FlutterKaigi 2023</title>
   <link rel="manifest" href="manifest.json">
 


### PR DESCRIPTION
## Issue

- close #68 ＃

## Overview (Required)

昨年とは測定ID を変えて Google Analytics 4 を導入しました。 

## Links

- https://github.com/FlutterKaigi/2022/blob/2c96d47c5f7d7d05c76be7c62cee7a028a858085/web/index.html#L28
