### PR TITLE
meta 情報を適正な内容に変更

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,7 @@
     gtag('config', 'G-7J6Q968NBL');
   </script>
 
+  <title>FlutterKaigi 2023</title>
   <link rel="manifest" href="manifest.json">
 
   <script>


### PR DESCRIPTION
## Issue

- close #49

## Overview (Required)

- SEO 対策の一環として meta 情報を適正な内容に変更します。

## Links

- [Google が対応するメタタグとインラインタグ | Google 検索セントラル  |  ドキュメント  |  Google for Developers](https://developers.google.com/search/docs/crawling-indexing/special-tags?hl=ja)

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
