### PR TITLE
モバイル表示時のドロワーメニューのメニューアイテムが中央揃えに修正

### DIFF
--- a/lib/components/header/header_widget.dart
+++ b/lib/components/header/header_widget.dart
@@ -154,13 +154,15 @@ class _DrawerScreen extends StatelessWidget {
               ),
             ],
           ),
+          const SizedBox(height: 20),
           Padding(
-            padding: const EdgeInsets.all(15),
+            padding: const EdgeInsets.symmetric(horizontal: 15),
             child: Column(
               mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                ListTile(
-                  title: FittedBox(
+                InkWell(
+                  child: FittedBox(
                     alignment: Alignment.centerLeft,
                     fit: BoxFit.scaleDown,
                     child: FlutterKaigiLogo(
@@ -187,7 +189,6 @@ class _DrawerScreen extends StatelessWidget {
                     },
                     child: Row(
                       children: [
-                        const SizedBox(width: 11.5),
                         // 白ポチ
                         SizedBox(
                           width: 15,


### PR DESCRIPTION
## Issue

- close #86 

## Overview (Required)

- 横幅の調整についてはこちらの計算式で調整しました。
Figma：15(padding)+ 8(iconSize) + 16(padding) = 39
Flutter：11.5(padding) + 15(iconSize) * 12.5(padding) = 39

## Links

- https://flutterkaigi-2023-preview--pr91-feature-fix-drawer-c-ie9svmux.web.app/

## Screenshot

上がAfterで、下がBeforeです。


![スクリーンショット 2023-07-02 16 07 49（2）](https://github.com/FlutterKaigi/2023/assets/67954894/8c0e9794-21b1-42cf-8dc3-5cb6acf4305f)


