### PR TITLE
`MediaQuery.of` の代わりに `MediaQuery.sizeOf` を利用

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -60,7 +60,7 @@ class _MainPageBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
+    final width = MediaQuery.sizeOf(context).width;
     final largeScreenSize = ResponsiveWidget.largeScreenSize.toDouble();
 
     return SingleChildScrollView(

--- a/lib/core/components/responsive_widget.dart
+++ b/lib/core/components/responsive_widget.dart
@@ -24,7 +24,7 @@ class ResponsiveWidget extends StatelessWidget {
 
   /// Returns the screen size type based on the screen width
   static ScreenSizeType getScreenSizeType(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    final screenWidth = MediaQuery.sizeOf(context).width;
     return switch (screenWidth) {
       > largeScreenSize => ScreenSizeType.large,
       > mediumScreenSize => ScreenSizeType.medium,

--- a/lib/features/footer/ui/footer.dart
+++ b/lib/features/footer/ui/footer.dart
@@ -10,7 +10,7 @@ class Footer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width,
+      width: MediaQuery.sizeOf(context).width,
       child: const DecoratedBox(
         decoration: BoxDecoration(
           gradient: LinearGradient(

--- a/lib/features/header/ui/header_widget.dart
+++ b/lib/features/header/ui/header_widget.dart
@@ -65,7 +65,7 @@ class HeaderBar extends HookWidget implements PreferredSizeWidget {
       ],
     );
 
-    final width = MediaQuery.of(context).size.width;
+    final width = MediaQuery.sizeOf(context).width;
     final largeScreenSize = ResponsiveWidget.largeScreenSize.toDouble();
     final desktopBar = Center(
       child: SizedBox(


### PR DESCRIPTION
## Issue

- close #109 

## Overview (Required)

- 描画高速化のために `MediaQuery.of(context)` の代わりに `MediaQuery.sizeOf(context)` を利用します
  - 端末の回転など描画サイズに変更がされたときだけリビルドされるようになります