### PR TITLE
`StaffSection` のリファクタリング

### DIFF
--- a/lib/core/foundation/iterable_ex.dart
+++ b/lib/core/foundation/iterable_ex.dart
@@ -1,0 +1,46 @@
+import 'package:collection/collection.dart';
+
+enum InsertLocation {
+  around,
+  between,
+}
+
+extension IterableEx<E> on Iterable<E> {
+  List<E> insertingEach(
+    E Function() toElement, {
+    InsertLocation location = InsertLocation.between,
+  }) {
+    return insertingListEach(() => [toElement()], location: location);
+  }
+
+  List<E> insertingListEach(
+    List<E> Function() toElements, {
+    InsertLocation location = InsertLocation.between,
+  }) {
+    switch (location) {
+      case InsertLocation.around:
+        final lastIndex = length - 1;
+        return foldIndexed([], (index, acc, item) {
+          final base = [...acc, item];
+          if (index == 0) {
+            return [...toElements(), ...base];
+          } else if (index == lastIndex) {
+            return [...base, ...toElements()];
+          } else {
+            return base;
+          }
+        });
+
+      case InsertLocation.between:
+        final lastIndex = length - 1;
+        return foldIndexed([], (index, acc, item) {
+          final base = [...acc, item];
+          if (index == lastIndex) {
+            return base;
+          } else {
+            return [...base, ...toElements()];
+          }
+        });
+    }
+  }
+}

--- a/lib/features/staff/ui/staff_item.dart
+++ b/lib/features/staff/ui/staff_item.dart
@@ -13,8 +13,6 @@ class StaffItem extends StatelessWidget {
 
   final Staff staff;
 
-  static const spacing = 16.0;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);

--- a/lib/features/staff/ui/staff_item.dart
+++ b/lib/features/staff/ui/staff_item.dart
@@ -1,0 +1,106 @@
+import 'package:confwebsite2023/core/theme.dart';
+import 'package:confwebsite2023/features/staff/data/staff.dart';
+import 'package:confwebsite2023/features/staff/ui/sns_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:transparent_image/transparent_image.dart';
+import 'package:url_launcher/link.dart';
+
+class StaffItem extends StatelessWidget {
+  const StaffItem({
+    required this.staff,
+    super.key,
+  });
+
+  final Staff staff;
+
+  static const spacing = 16.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final icon = SizedBox(
+      height: 120,
+      width: 120,
+      child: FittedBox(
+        child: ClipOval(
+          child: FadeInImage(
+            fit: BoxFit.cover,
+            image: NetworkImage(staff.image.src),
+            placeholder: MemoryImage(kTransparentImage),
+            imageErrorBuilder: (_, __, ___) => const FittedBox(
+              child: Icon(
+                Icons.error,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final snsIcons = Wrap(
+      alignment: WrapAlignment.center,
+      children: [
+        ...staff.sns.map(
+          (e) => Link(
+            target: LinkTarget.blank,
+            uri: Uri.tryParse(e.type.prefixUrl + e.value),
+            builder: (_, followLink) => SnsIcon(
+              snsType: e.type,
+              size: 32,
+              padding: EdgeInsets.zero,
+              iconColor: theme.colorScheme.onPrimaryContainer,
+              onPressed: followLink,
+            ),
+          ),
+        ),
+      ],
+    );
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      color: theme.colorScheme.secondaryContainer,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 16,
+              left: 24,
+              right: 24,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                icon,
+                Spaces.vertical_16,
+                Text(
+                  staff.displayName,
+                  style: theme.textTheme.titleLarge!.copyWith(
+                    color: baselineColorScheme.ref.primary.primary100,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                Spaces.vertical_8,
+                Text(
+                  staff.introduction,
+                  style: theme.textTheme.bodyLarge!.copyWith(
+                    color: baselineColorScheme.ref.primary.primary80,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
+          Spaces.vertical_16,
+          snsIcons,
+          Spaces.vertical_16,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/staff/ui/staff_row.dart
+++ b/lib/features/staff/ui/staff_row.dart
@@ -13,6 +13,8 @@ class StaffRow extends StatelessWidget {
   final List<Staff> staffs;
   final double itemWidth;
 
+  static const spacing = 16.0;
+
   // 余白を考慮しつつ 最大横に何個並べられるかを計算する
   static int calculateItemCount({
     required double maxWidth,
@@ -48,7 +50,7 @@ class StaffRow extends StatelessWidget {
           ),
         )
       ].insertingEach(
-        () => const SizedBox(width: StaffItem.spacing),
+        () => const SizedBox(width: spacing),
       ),
     );
   }

--- a/lib/features/staff/ui/staff_row.dart
+++ b/lib/features/staff/ui/staff_row.dart
@@ -6,12 +6,12 @@ import 'package:flutter/widgets.dart';
 class StaffRow extends StatelessWidget {
   const StaffRow({
     required this.staffs,
-    required this.itemWidth,
+    required this.maxWidth,
     super.key,
   });
 
   final List<Staff> staffs;
-  final double itemWidth;
+  final double maxWidth;
 
   static const spacing = 16.0;
 
@@ -45,7 +45,9 @@ class StaffRow extends StatelessWidget {
       children: [
         ...staffs.map<Widget>(
           (staff) => SizedBox(
-            width: itemWidth,
+            width: calculateItemWidth(
+              maxWidth: maxWidth,
+            ),
             child: StaffItem(staff: staff),
           ),
         )

--- a/lib/features/staff/ui/staff_row.dart
+++ b/lib/features/staff/ui/staff_row.dart
@@ -29,6 +29,13 @@ class StaffRow extends StatelessWidget {
     };
   }
 
+  static double calculateItemWidth({
+    required double maxWidth,
+  }) {
+    final itemCount = calculateItemCount(maxWidth: maxWidth);
+    return (maxWidth - spacing * (itemCount - 1)) / itemCount;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(

--- a/lib/features/staff/ui/staff_row.dart
+++ b/lib/features/staff/ui/staff_row.dart
@@ -1,0 +1,32 @@
+import 'package:confwebsite2023/core/foundation/iterable_ex.dart';
+import 'package:confwebsite2023/features/staff/data/staff.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
+import 'package:flutter/widgets.dart';
+
+class StaffRow extends StatelessWidget {
+  const StaffRow({
+    required this.staffs,
+    required this.itemWidth,
+    super.key,
+  });
+
+  final List<Staff> staffs;
+  final double itemWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ...staffs.map<Widget>(
+          (staff) => SizedBox(
+            width: itemWidth,
+            child: StaffItem(staff: staff),
+          ),
+        )
+      ].insertingEach(
+        () => const SizedBox(width: StaffItem.spacing),
+      ),
+    );
+  }
+}

--- a/lib/features/staff/ui/staff_row.dart
+++ b/lib/features/staff/ui/staff_row.dart
@@ -13,6 +13,22 @@ class StaffRow extends StatelessWidget {
   final List<Staff> staffs;
   final double itemWidth;
 
+  // 余白を考慮しつつ 最大横に何個並べられるかを計算する
+  static int calculateItemCount({
+    required double maxWidth,
+  }) {
+    // yを最大横幅 xを横の最大要素数として、
+    // y = 171x + spacing * (x - 1)
+    // y + spacing = (171 + spacing) * x
+    // x = (y + spacing) / (171 + spacing)
+    final result = ((maxWidth - spacing) / (171 + spacing)).floor();
+    return switch (result) {
+      < 2 => 2,
+      > 5 => 5,
+      _ => result,
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(

--- a/lib/features/staff/ui/staff_section.dart
+++ b/lib/features/staff/ui/staff_section.dart
@@ -1,11 +1,8 @@
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/components/section_header.dart';
 import 'package:confwebsite2023/core/theme/app_text_style.dart';
-import 'package:confwebsite2023/features/staff/data/staff_provider.dart';
-import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
-import 'package:confwebsite2023/features/staff/ui/staff_row.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_table.dart';
 import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class StaffSection extends StatelessWidget {
   const StaffSection({super.key});
@@ -31,95 +28,8 @@ class StaffSection extends StatelessWidget {
             ),
           ],
         ),
-        const _StaffList(),
+        const StaffTable(),
       ],
     );
-  }
-}
-
-class _StaffList extends ConsumerWidget {
-  const _StaffList();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(sortedStaffsProvider);
-    return state.when(
-      data: (data) {
-        return Container(
-          alignment: Alignment.center,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              // 余白を考慮しつつ 最大横に何個並べられるかを計算する
-              // yを最大横幅 xを横の最大要素数として、
-              // y = 171x + 16(x - 1)
-              // y - 16 = 187x
-              // x = (y - 16) / 187
-              final result = ((constraints.maxWidth - 16) / 187).floor();
-              final crossAxisCount = switch (result) {
-                < 2 => 2,
-                > 5 => 5,
-                _ => result,
-              };
-              // 要素の横幅を計算
-              final itemWidth =
-                  (constraints.maxWidth - 16 * (crossAxisCount - 1)) /
-                      crossAxisCount;
-
-              final staffs = data.chunked(crossAxisCount);
-              return SizedBox(
-                width: constraints.maxWidth,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ...staffs
-                        .map<Widget>(
-                          (staffsInRow) => IntrinsicHeight(
-                            child: StaffRow(
-                              staffs: staffsInRow,
-                              itemWidth: itemWidth,
-                            ),
-                          ),
-                        )
-                        .toList()
-                        .joinElement(
-                          const SizedBox(height: StaffItem.spacing),
-                        ),
-                    const SizedBox(height: 165),
-                  ],
-                ),
-              );
-            },
-          ),
-        );
-      },
-      error: (error, stackTrace) {
-        return Text('エラーが発生しました: $error');
-      },
-      loading: () {
-        return const CircularProgressIndicator.adaptive();
-      },
-    );
-  }
-}
-
-extension _ListChunkExtension<T> on List<T> {
-  List<List<T>> chunked(int size) {
-    final result = <List<T>>[];
-    for (var i = 0; i < length; i += size) {
-      result.add(sublist(i, i + size > length ? length : i + size));
-    }
-    return result;
-  }
-
-  List<T> joinElement(T element) {
-    final result = <T>[];
-    for (var i = 0; i < length; i++) {
-      result.add(this[i]);
-      if (i != length - 1) {
-        result.add(element);
-      }
-    }
-    return result;
   }
 }

--- a/lib/features/staff/ui/staff_section.dart
+++ b/lib/features/staff/ui/staff_section.dart
@@ -3,6 +3,7 @@ import 'package:confwebsite2023/core/components/section_header.dart';
 import 'package:confwebsite2023/core/theme/app_text_style.dart';
 import 'package:confwebsite2023/features/staff/data/staff_provider.dart';
 import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_row.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -74,19 +75,9 @@ class _StaffList extends ConsumerWidget {
                     ...staffs
                         .map<Widget>(
                           (staffsInRow) => IntrinsicHeight(
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: staffsInRow
-                                  .map<Widget>(
-                                    (e) => SizedBox(
-                                      width: itemWidth,
-                                      child: StaffItem(staff: e),
-                                    ),
-                                  )
-                                  .toList()
-                                  .joinElement(
-                                    const SizedBox(width: StaffItem.spacing),
-                                  ),
+                            child: StaffRow(
+                              staffs: staffsInRow,
+                              itemWidth: itemWidth,
                             ),
                           ),
                         )

--- a/lib/features/staff/ui/staff_section.dart
+++ b/lib/features/staff/ui/staff_section.dart
@@ -1,13 +1,10 @@
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/components/section_header.dart';
-import 'package:confwebsite2023/core/theme.dart';
-import 'package:confwebsite2023/features/staff/data/staff.dart';
+import 'package:confwebsite2023/core/theme/app_text_style.dart';
 import 'package:confwebsite2023/features/staff/data/staff_provider.dart';
-import 'package:confwebsite2023/features/staff/ui/sns_icon.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:transparent_image/transparent_image.dart';
-import 'package:url_launcher/link.dart';
 
 class StaffSection extends StatelessWidget {
   const StaffSection({super.key});
@@ -83,21 +80,21 @@ class _StaffList extends ConsumerWidget {
                                   .map<Widget>(
                                     (e) => SizedBox(
                                       width: itemWidth,
-                                      child: _StaffItem(staff: e),
+                                      child: StaffItem(staff: e),
                                     ),
                                   )
                                   .toList()
                                   .joinElement(
-                                    const SizedBox(width: _StaffItem.spacing),
+                                    const SizedBox(width: StaffItem.spacing),
                                   ),
                             ),
                           ),
                         )
                         .toList()
                         .joinElement(
-                          const SizedBox(height: _StaffItem.spacing),
+                          const SizedBox(height: StaffItem.spacing),
                         ),
-                    Spaces.vertical_200,
+                    const SizedBox(height: 165),
                   ],
                 ),
               );
@@ -111,104 +108,6 @@ class _StaffList extends ConsumerWidget {
       loading: () {
         return const CircularProgressIndicator.adaptive();
       },
-    );
-  }
-}
-
-class _StaffItem extends StatelessWidget {
-  const _StaffItem({
-    required this.staff,
-  });
-  final Staff staff;
-
-  static const spacing = 16.0;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final icon = SizedBox(
-      height: 120,
-      width: 120,
-      child: FittedBox(
-        child: ClipOval(
-          child: FadeInImage(
-            fit: BoxFit.cover,
-            image: NetworkImage(staff.image.src),
-            placeholder: MemoryImage(kTransparentImage),
-            imageErrorBuilder: (_, __, ___) => const FittedBox(
-              child: Icon(
-                Icons.error,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final snsIcons = Wrap(
-      alignment: WrapAlignment.center,
-      children: staff.sns
-          .map(
-            (e) => Link(
-              target: LinkTarget.blank,
-              uri: Uri.tryParse(e.type.prefixUrl + e.value),
-              builder: (_, followLink) => SnsIcon(
-                snsType: e.type,
-                size: 32,
-                padding: EdgeInsets.zero,
-                iconColor: theme.colorScheme.onPrimaryContainer,
-                onPressed: followLink,
-              ),
-            ),
-          )
-          .toList(),
-    );
-
-    return Card(
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-      ),
-      color: theme.colorScheme.secondaryContainer,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(
-              top: 16,
-              left: 24,
-              right: 24,
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                icon,
-                Spaces.vertical_16,
-                Text(
-                  staff.displayName,
-                  style: theme.textTheme.titleLarge!.copyWith(
-                    color: baselineColorScheme.ref.primary.primary100,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                Spaces.vertical_8,
-                Text(
-                  staff.introduction,
-                  style: theme.textTheme.bodyLarge!.copyWith(
-                    color: baselineColorScheme.ref.primary.primary80,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
-          ),
-          const Spacer(),
-          Spaces.vertical_16,
-          snsIcons,
-          Spaces.vertical_16,
-        ],
-      ),
     );
   }
 }

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -23,9 +23,9 @@ class StaffTable extends ConsumerWidget {
               final itemCount = StaffRow.calculateItemCount(
                 maxWidth: constraints.maxWidth,
               );
-              // 要素の横幅を計算
-              final itemWidth =
-                  (constraints.maxWidth - 16 * (itemCount - 1)) / itemCount;
+              final itemWidth = StaffRow.calculateItemWidth(
+                maxWidth: constraints.maxWidth,
+              );
 
               final staffs = data.chunked(itemCount);
               return SizedBox(

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -22,9 +22,6 @@ class StaffTable extends ConsumerWidget {
               final itemCount = StaffRow.calculateItemCount(
                 maxWidth: constraints.maxWidth,
               );
-              final itemWidth = StaffRow.calculateItemWidth(
-                maxWidth: constraints.maxWidth,
-              );
 
               final chunkedAllStaffs = data.chunked(itemCount);
               return SizedBox(
@@ -36,7 +33,7 @@ class StaffTable extends ConsumerWidget {
                       (staffsInRow) => IntrinsicHeight(
                         child: StaffRow(
                           staffs: staffsInRow,
-                          itemWidth: itemWidth,
+                          maxWidth: constraints.maxWidth,
                         ),
                       ),
                     ),

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -1,6 +1,5 @@
 import 'package:confwebsite2023/core/foundation/iterable_ex.dart';
 import 'package:confwebsite2023/features/staff/data/staff_provider.dart';
-import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
 import 'package:confwebsite2023/features/staff/ui/staff_row.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -42,7 +41,7 @@ class StaffTable extends ConsumerWidget {
                       ),
                     ),
                   ].insertingEach(
-                    () => const SizedBox(height: StaffItem.spacing),
+                    () => const SizedBox(height: StaffRow.spacing),
                   ),
                 ),
               );

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -1,0 +1,80 @@
+import 'package:confwebsite2023/core/foundation/iterable_ex.dart';
+import 'package:confwebsite2023/features/staff/data/staff_provider.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_item.dart';
+import 'package:confwebsite2023/features/staff/ui/staff_row.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class StaffTable extends ConsumerWidget {
+  const StaffTable({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(sortedStaffsProvider);
+    return state.when(
+      data: (data) {
+        return Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // 余白を考慮しつつ 最大横に何個並べられるかを計算する
+              // yを最大横幅 xを横の最大要素数として、
+              // y = 171x + 16(x - 1)
+              // y - 16 = 187x
+              // x = (y - 16) / 187
+              final result = ((constraints.maxWidth - 16) / 187).floor();
+              final crossAxisCount = switch (result) {
+                < 2 => 2,
+                > 5 => 5,
+                _ => result,
+              };
+              // 要素の横幅を計算
+              final itemWidth =
+                  (constraints.maxWidth - 16 * (crossAxisCount - 1)) /
+                      crossAxisCount;
+
+              final staffs = data.chunked(crossAxisCount);
+              return SizedBox(
+                width: constraints.maxWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ...staffs.map<Widget>(
+                      (staffsInRow) => IntrinsicHeight(
+                        child: StaffRow(
+                          staffs: staffsInRow,
+                          itemWidth: itemWidth,
+                        ),
+                      ),
+                    ),
+                  ].insertingEach(
+                    () => const SizedBox(height: StaffItem.spacing),
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+      error: (error, stackTrace) {
+        return Text('エラーが発生しました: $error');
+      },
+      loading: () {
+        return const CircularProgressIndicator.adaptive();
+      },
+    );
+  }
+}
+
+extension _ListChunkExtension<T> on List<T> {
+  List<List<T>> chunked(int size) {
+    final result = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      result.add(sublist(i, i + size > length ? length : i + size));
+    }
+    return result;
+  }
+}

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -26,13 +26,13 @@ class StaffTable extends ConsumerWidget {
                 maxWidth: constraints.maxWidth,
               );
 
-              final staffs = data.chunked(itemCount);
+              final chunkedAllStaffs = data.chunked(itemCount);
               return SizedBox(
                 width: constraints.maxWidth,
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    ...staffs.map<Widget>(
+                    ...chunkedAllStaffs.map<Widget>(
                       (staffsInRow) => IntrinsicHeight(
                         child: StaffRow(
                           staffs: staffsInRow,

--- a/lib/features/staff/ui/staff_table.dart
+++ b/lib/features/staff/ui/staff_table.dart
@@ -20,23 +20,14 @@ class StaffTable extends ConsumerWidget {
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: LayoutBuilder(
             builder: (context, constraints) {
-              // 余白を考慮しつつ 最大横に何個並べられるかを計算する
-              // yを最大横幅 xを横の最大要素数として、
-              // y = 171x + 16(x - 1)
-              // y - 16 = 187x
-              // x = (y - 16) / 187
-              final result = ((constraints.maxWidth - 16) / 187).floor();
-              final crossAxisCount = switch (result) {
-                < 2 => 2,
-                > 5 => 5,
-                _ => result,
-              };
+              final itemCount = StaffRow.calculateItemCount(
+                maxWidth: constraints.maxWidth,
+              );
               // 要素の横幅を計算
               final itemWidth =
-                  (constraints.maxWidth - 16 * (crossAxisCount - 1)) /
-                      crossAxisCount;
+                  (constraints.maxWidth - 16 * (itemCount - 1)) / itemCount;
 
-              final staffs = data.chunked(crossAxisCount);
+              final staffs = data.chunked(itemCount);
               return SizedBox(
                 width: constraints.maxWidth,
                 child: Column(

--- a/test/core/foundation/iterable_ex_test.dart
+++ b/test/core/foundation/iterable_ex_test.dart
@@ -1,0 +1,84 @@
+import 'package:confwebsite2023/core/foundation/iterable_ex.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('#insertingEach', () {
+    group('between', () {
+      test('insert between two elements', () {
+        final base = [1, 3];
+        final expected = [1, 2, 3];
+
+        expect(base.insertingEach(() => 2), orderedEquals(expected));
+      });
+
+      test('insert between three elements', () {
+        final base = [1, 2, 3];
+        final expected = [1, 4, 2, 4, 3];
+
+        expect(base.insertingEach(() => 4), orderedEquals(expected));
+      });
+    });
+
+    group('around', () {
+      test('insert around two elements', () {
+        final base = [1, 3];
+        final expected = [2, 1, 3, 2];
+
+        expect(
+          base.insertingEach(() => 2, location: InsertLocation.around),
+          orderedEquals(expected),
+        );
+      });
+
+      test('insert around three elements', () {
+        final base = [1, 2, 3];
+        final expected = [4, 1, 2, 3, 4];
+
+        expect(
+          base.insertingEach(() => 4, location: InsertLocation.around),
+          orderedEquals(expected),
+        );
+      });
+    });
+  });
+
+  group('#insertingListEach', () {
+    group('between', () {
+      test('insert between two elements', () {
+        final base = [1, 4];
+        final expected = [1, 2, 3, 4];
+
+        expect(base.insertingListEach(() => [2, 3]), orderedEquals(expected));
+      });
+
+      test('insert between three elements', () {
+        final base = [1, 2, 3];
+        final expected = [1, 4, 4, 2, 4, 4, 3];
+
+        expect(base.insertingListEach(() => [4, 4]), orderedEquals(expected));
+      });
+    });
+
+    group('around', () {
+      test('insert around two elements', () {
+        final base = [2, 3];
+        final expected = [1, 1, 2, 3, 1, 1];
+
+        expect(
+          base.insertingListEach(() => [1, 1], location: InsertLocation.around),
+          orderedEquals(expected),
+        );
+      });
+
+      test('insert around three elements', () {
+        final base = [2, 3, 4];
+        final expected = [1, 1, 2, 3, 4, 1, 1];
+
+        expect(
+          base.insertingListEach(() => [1, 1], location: InsertLocation.around),
+          orderedEquals(expected),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Overview (Required)

- `iterable_ex` を追加
  - [intersperse | Dart Package](https://pub.dev/packages/intersperse)の自作みたいな感じです
- #93 の調査を行いつつ、`StaffSection` のリファクタリングを行いました

### Before 

- `StaffSection` のprivate class

### After

- `StaffSection` (その名の通りスタッフセクション全体)
  - `StaffTable` (スタッフのテーブル表示部分)
    - `StaffRow` (スタッフの一行分)
      - `StaffItem` (一つのスタッフ)

という構造になりました。