### PR TITLE
Drawer内のレイアウト・デザインを修正

### DIFF
--- a/lib/core/theme/dimension.dart
+++ b/lib/core/theme/dimension.dart
@@ -5,7 +5,6 @@ class Spaces {
 
   static const SizedBox horizontal_10 = SizedBox(width: 10);
   static const SizedBox horizontal_12 = SizedBox(width: 12);
-  static const SizedBox horizontal_12_5 = SizedBox(width: 12.5);
   static const SizedBox horizontal_16 = SizedBox(width: 16);
   static const SizedBox horizontal_20 = SizedBox(width: 20);
   static const SizedBox horizontal_40 = SizedBox(width: 40);

--- a/lib/features/header/ui/header_widget.dart
+++ b/lib/features/header/ui/header_widget.dart
@@ -171,7 +171,7 @@ class _DrawerScreen extends StatelessWidget {
                     fit: BoxFit.scaleDown,
                     child: FlutterKaigiLogo(
                       style: FlutterKaigiLogoStyle.horizontal,
-                      textStyle: theme.textTheme.titleLarge!.copyWith(
+                      textStyle: GoogleFonts.poppins(
                         fontWeight: FontWeight.w600,
                         fontSize: 24,
                       ),

--- a/lib/features/header/ui/header_widget.dart
+++ b/lib/features/header/ui/header_widget.dart
@@ -193,21 +193,21 @@ class _DrawerScreen extends StatelessWidget {
                     },
                     child: Row(
                       children: [
-                        // 白ポチ
-                        SizedBox(
-                          width: 15,
-                          height: 15,
-                          child: Icon(
-                            Icons.circle,
-                            color:
-                                baselineColorScheme.ref.secondary.secondary70,
-                            size: 8,
+                        Container(
+                          width: 8,
+                          height: 8,
+                          decoration: BoxDecoration(
+                            color: baselineColorScheme.ref.primary.primary70,
+                            shape: BoxShape.circle,
                           ),
                         ),
-                        Spaces.horizontal_12_5,
+                        Spaces.horizontal_16,
                         Text(
                           e.title,
-                          style: theme.textTheme.titleLarge,
+                          style: theme.textTheme.titleLarge!.copyWith(
+                            color:
+                                baselineColorScheme.ref.secondary.secondary99,
+                          ),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Issue

- Closeするものはありません

## Overview (Required)
- モバイル表示の`_DrawerScreen`内でFigmaデザインとの相違があったので修正しました

## Details
- `FlutterKaigi 2023`のフォントの太さが適切に設定されていませんでした。修正しました
  - `FontWeight`を変更する場合、`GoogleFonts.poppins()`からアクセスする必要があります。
- `Staff`と書かれている`ListItem`の冒頭部 丸ポチのレイアウトを修正しました

|Before|After|
|------|-----|
|![image](https://github.com/FlutterKaigi/2023/assets/73390859/d4f763b7-eaeb-48ac-8b39-3e4c5784b483)|![image](https://github.com/FlutterKaigi/2023/assets/73390859/89dfa113-71fd-4126-8767-8d112a01be8e)|



