### PR TITLE
Improve: Flutter beta channel の使用理由を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project uses [Flutter beta channel]. The reasons:
 A Run Configuration is set up to run this app.
 
 Please check:
-- `.vscode/launch.json` for VS Code
+- `.vscode/launch.json` for VS Code.
 - `.run/~.run.xml` for IntelliJ IDEA or Android Studio.
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This project uses [Flutter beta channel].
 A Run Configuration is set up to run this app.
 
 Please check:
-    - `.vscode/launch.json` for VS Code
-    - `.run/~.run.xml` for IntelliJ IDEA or Android Studio.
+- `.vscode/launch.json` for VS Code
+- `.run/~.run.xml` for IntelliJ IDEA or Android Studio.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We will deliver sessions related to FlutterKaigi in accordance with [Figma].
 
 This project uses [Flutter beta channel]. The reasons:
 - Use the latest Flutter/Dart features.
-- Use a more stable version
+- Use a more stable version than master channel.
 
 1. [Install fvm].
 1. Move to project root directory, and run `fvm install` command.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ We will deliver sessions related to FlutterKaigi in accordance with [Figma].
 
 ### Setup
 
-This project uses [Flutter beta channel].
+This project uses [Flutter beta channel]. The reason:
+- Use the latest Flutter/Dart features.
+- Use a more stable version
 
 1. [Install fvm].
 1. Move to project root directory, and run `fvm install` command.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ## Development
 
-We will deliver sessions related to FlutterKaigi in accordance with [Figma](https://www.figma.com/file/LsVB4KlIMXD4Z1FfB8KyuU/FlutterKaigi-Web-2023).
+We will deliver sessions related to FlutterKaigi in accordance with [Figma].
 
 ### Setup
 
-This project uses [Flutter beta channel](https://github.com/flutter/flutter/wiki/Roadmap#releases).
+This project uses [Flutter beta channel].
 
-1. [Install fvm](https://fvm.app/docs/getting_started/installation).
+1. [Install fvm].
 1. Move to project root directory, and run `fvm install` command.
 1. Run `fvm flutter pub get` command.
 1. Set up IDE to use fvm.
-    - If you use [VSCode](https://code.visualstudio.com/), already set up.
-    - If you use [Android Studio](https://developer.android.com/studio), please see [fvm document](https://fvm.app/docs/getting_started/configuration#android-studio).
+    - If you use [VSCode], already set up.
+    - If you use [Android Studio], please see [fvm document].
 
 ### Run app
 
@@ -25,9 +25,9 @@ Please check:
 
 ### Contributing
 
-We always welcome all contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
+We always welcome all contributions! See [CONTRIBUTING.md] for more information.
 
-For Japanese, please see [CONTRIBUTING.ja.md](./CONTRIBUTING.ja.md).
+For Japanese, please see [CONTRIBUTING.ja.md].
 
 ### Branch Rules
 
@@ -41,10 +41,10 @@ We would be happy if you could create a branch with the following rules
 
 ### Tech Stacks
 
-- [Flutter](https://flutter.dev/)
-- [Flutter Web](https://docs.flutter.dev/deployment/web)
-- [GitHub Pages](https://docs.github.com/ja/pages/getting-started-with-github-pages/about-github-pages)
-- [Codemagic Static Pages](https://docs.codemagic.io/flutter-publishing/publishing-to-codemagic-static-pages/)
+- [Flutter]
+- [Flutter Web]
+- [GitHub Pages]
+- [Codemagic Static Pages]
 
 ### Directory Structure
 
@@ -85,4 +85,32 @@ Thank you for contributing!
 
 ### Contributors
 
-GitHub: [Contributors](https://github.com/FlutterKaigi/2023/graphs/contributors)
+GitHub: [Contributors]
+
+<!-- Links -->
+
+[Figma]: https://www.figma.com/file/LsVB4KlIMXD4Z1FfB8KyuU/FlutterKaigi-Web-2023
+
+[Flutter beta channel]: https://github.com/flutter/flutter/wiki/Roadmap#releases
+
+[Install fvm]: https://fvm.app/docs/getting_started/installation
+
+[VSCode]: https://code.visualstudio.com/
+
+[Android Studio]: https://developer.android.com/studio
+
+[fvm document]: https://fvm.app/docs/getting_started/configuration#android-studio
+
+[CONTRIBUTING.md]: ./CONTRIBUTING.md
+
+[CONTRIBUTING.ja.md]: ./CONTRIBUTING.ja.md
+
+[Flutter]: https://flutter.dev/
+
+[Flutter Web]: https://docs.flutter.dev/deployment/web
+
+[GitHub Pages]: https://docs.github.com/ja/pages/getting-started-with-github-pages/about-github-pages
+
+[Codemagic Static Pages]: https://docs.codemagic.io/flutter-publishing/publishing-to-codemagic-static-pages/
+
+[Contributors]: https://github.com/FlutterKaigi/2023/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We will deliver sessions related to FlutterKaigi in accordance with [Figma].
 
 ### Setup
 
-This project uses [Flutter beta channel]. The reason:
+This project uses [Flutter beta channel]. The reasons:
 - Use the latest Flutter/Dart features.
 - Use a more stable version
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We would be happy if you could create a branch with the following rules
 
 - [Flutter](https://flutter.dev/)
 - [Flutter Web](https://docs.flutter.dev/deployment/web)
-- [Github Pages](https://docs.github.com/ja/pages/getting-started-with-github-pages/about-github-pages)
+- [GitHub Pages](https://docs.github.com/ja/pages/getting-started-with-github-pages/about-github-pages)
 - [Codemagic Static Pages](https://docs.codemagic.io/flutter-publishing/publishing-to-codemagic-static-pages/)
 
 ### Directory Structure


### PR DESCRIPTION
## Issue

- close #129 

## Overview (Required)

Flutter beta channel を使っている理由を追記しました。

あと、以下のような微修正も行いました。

- typo を修正（ Github → GitHub ）
- リンクを下部に集約して可読性を向上
- リストの表示崩れを修正

## Screenshot

UI の修正ではないため省略