### PR TITLE
refactor: 位置に関する調整を SectionHeader 内で完結するよう変更

### DIFF
--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -10,7 +10,7 @@ class SectionHeader extends StatelessWidget {
   });
 
   /// ブラーのぼかし範囲
-  static const double blurRadius = 20;
+  static const double _blurRadius = 20;
 
   /// The text to display.
   final String text;
@@ -21,7 +21,7 @@ class SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Transform.translate(
       // NOTE: ブラーのぼかし範囲を考慮してオフセットを設定する
-      offset: const Offset(-SectionHeader.blurRadius, 0),
+      offset: const Offset(-SectionHeader._blurRadius, 0),
       child: ShaderMask(
         shaderCallback: (Rect bounds) {
           // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
@@ -33,7 +33,7 @@ class SectionHeader extends StatelessWidget {
         blendMode: BlendMode.srcIn,
         child: Padding(
           // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
-          padding: const EdgeInsets.all(blurRadius),
+          padding: const EdgeInsets.all(_blurRadius),
           child: Text(
             text,
             style: style.copyWith(

--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -19,19 +19,45 @@ class SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ShaderMask(
-      shaderCallback: (Rect bounds) =>
-          GradientConstant.accent.primary.createShader(bounds),
-      child: Padding(
-        // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
-        padding: const EdgeInsets.all(blurRadius),
-        child: Text(
-          text,
-          style: style.copyWith(
-            color: Colors.white,
+    return Transform.translate(
+      // NOTE: ブラーのぼかし範囲を考慮してオフセットを設定する
+      offset: const Offset(-SectionHeader.blurRadius, 0),
+      child: ShaderMask(
+        shaderCallback: (Rect bounds) {
+          // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
+          final textSize = _getTextSize(maxWidth: bounds.width);
+          return GradientConstant.accent.primary.createShader(
+            Rect.fromLTWH(0, 0, textSize.width, textSize.height),
+          );
+        },
+        blendMode: BlendMode.srcIn,
+        child: Padding(
+          // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
+          padding: const EdgeInsets.all(blurRadius),
+          child: Text(
+            text,
+            style: style.copyWith(
+              color: Colors.white,
+            ),
           ),
         ),
       ),
     );
+  }
+
+  /// 描画するテキストのサイズを取得する
+  Size _getTextSize({
+    required double maxWidth,
+  }) {
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: style,
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(
+        maxWidth: maxWidth,
+      );
+    return textPainter.size;
   }
 }

--- a/lib/core/components/wanted.dart
+++ b/lib/core/components/wanted.dart
@@ -72,16 +72,13 @@ class WantedDesktop extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Transform.translate(
-          offset: const Offset(-SectionHeader.blurRadius, 0),
-          child: SectionHeader(
-            text: title,
-            style: GoogleFonts.poppins(
-              fontSize: 60,
-              fontStyle: FontStyle.italic,
-              fontWeight: FontWeight.w700,
-              height: 1.1,
-            ),
+        SectionHeader(
+          text: title,
+          style: GoogleFonts.poppins(
+            fontSize: 60,
+            fontStyle: FontStyle.italic,
+            fontWeight: FontWeight.w700,
+            height: 1.1,
           ),
         ),
         Spaces.vertical_24,
@@ -185,16 +182,13 @@ class WantedMobile extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Transform.translate(
-          offset: const Offset(-SectionHeader.blurRadius, 0),
-          child: SectionHeader(
-            text: title,
-            style: GoogleFonts.poppins(
-              fontSize: 48,
-              fontStyle: FontStyle.italic,
-              fontWeight: FontWeight.w700,
-              height: 1.1,
-            ),
+        SectionHeader(
+          text: title,
+          style: GoogleFonts.poppins(
+            fontSize: 48,
+            fontStyle: FontStyle.italic,
+            fontWeight: FontWeight.w700,
+            height: 1.1,
           ),
         ),
         Spaces.vertical_24,

--- a/lib/features/staff/ui/staff_header.dart
+++ b/lib/features/staff/ui/staff_header.dart
@@ -8,22 +8,15 @@ class StaffHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Transform.translate(
-          offset: const Offset(-SectionHeader.blurRadius, 0),
-          child: ResponsiveWidget(
-            largeWidget: SectionHeader(
-              text: 'Staff',
-              style: AppTextStyle.pcHeading1,
-            ),
-            smallWidget: SectionHeader(
-              text: 'Staff',
-              style: AppTextStyle.spHeading1,
-            ),
-          ),
-        ),
-      ],
+    return ResponsiveWidget(
+      largeWidget: SectionHeader(
+        text: 'Staff',
+        style: AppTextStyle.pcHeading1,
+      ),
+      smallWidget: SectionHeader(
+        text: 'Staff',
+        style: AppTextStyle.spHeading1,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Overview (Required)

- 位置に関する調整を SectionHeader 内で完結するよう実装内容を変更します。

## Links

- [TextPainter class - painting library - Dart API](https://api.flutter.dev/flutter/painting/TextPainter-class.html)

## Screenshot

### モバイル

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/FlutterKaigi/2023/assets/19267812/7ebe0e36-00f1-4a71-83ad-53ebafa5987f" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/19267812/59121d8c-3261-40f0-8d47-6bbe4a15dbc2" width="300" /> |
| <img src="https://github.com/FlutterKaigi/2023/assets/19267812/58766570-b09f-4907-a373-e847979c121f" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/19267812/4f3b47ec-8449-46ba-927a-ea4d09c79caa" width="300" /> |

### PC

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/FlutterKaigi/2023/assets/19267812/cc206add-a016-4064-942b-289494acbaeb" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/19267812/5a4c5a69-6c07-44e4-ac04-40ff84943452" width="300" /> |
| <img src="https://github.com/FlutterKaigi/2023/assets/19267812/756c5936-1bea-453b-8d3c-c69e775a204d" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/19267812/c92565b1-b63d-4429-99f1-0576dfd4db5f" width="300" /> |
