### PR TITLE
セッション関係のモデルを追加

### DIFF
--- a/lib/features/session/model/session.dart
+++ b/lib/features/session/model/session.dart
@@ -1,0 +1,36 @@
+import 'package:confwebsite2023/features/session/model/speaker.dart';
+import 'package:confwebsite2023/features/session/model/track.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session.freezed.dart';
+part 'session.g.dart';
+
+@Freezed(unionKey: 'type')
+class Session with _$Session {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory Session.timeslot({
+    required String uuid,
+    required String title,
+    required DateTime startsAt,
+    required int lengthMin,
+    required Track track,
+    String? abstract,
+  }) = TimeslotSession;
+
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory Session.talk({
+    required String uuid,
+    required String url,
+    required String title,
+    required String abstract,
+    required Track track,
+    required DateTime startsAt,
+    required int lengthMin,
+    required Speaker speaker,
+  }) = TalkSession;
+
+  const factory Session.lunch() = LunchSession;
+
+  factory Session.fromJson(Map<String, dynamic> json) =>
+      _$SessionFromJson(json);
+}

--- a/lib/features/session/model/session.freezed.dart
+++ b/lib/features/session/model/session.freezed.dart
@@ -1,0 +1,805 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Session _$SessionFromJson(Map<String, dynamic> json) {
+  switch (json['type']) {
+    case 'timeslot':
+      return TimeslotSession.fromJson(json);
+    case 'talk':
+      return TalkSession.fromJson(json);
+    case 'lunch':
+      return LunchSession.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(
+          json, 'type', 'Session', 'Invalid union type "${json['type']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$Session {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)
+        timeslot,
+    required TResult Function(
+            String uuid,
+            String url,
+            String title,
+            String abstract,
+            Track track,
+            DateTime startsAt,
+            int lengthMin,
+            Speaker speaker)
+        talk,
+    required TResult Function() lunch,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult? Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult? Function()? lunch,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult Function()? lunch,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TimeslotSession value) timeslot,
+    required TResult Function(TalkSession value) talk,
+    required TResult Function(LunchSession value) lunch,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TimeslotSession value)? timeslot,
+    TResult? Function(TalkSession value)? talk,
+    TResult? Function(LunchSession value)? lunch,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TimeslotSession value)? timeslot,
+    TResult Function(TalkSession value)? talk,
+    TResult Function(LunchSession value)? lunch,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionCopyWith<$Res> {
+  factory $SessionCopyWith(Session value, $Res Function(Session) then) =
+      _$SessionCopyWithImpl<$Res, Session>;
+}
+
+/// @nodoc
+class _$SessionCopyWithImpl<$Res, $Val extends Session>
+    implements $SessionCopyWith<$Res> {
+  _$SessionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$TimeslotSessionCopyWith<$Res> {
+  factory _$$TimeslotSessionCopyWith(
+          _$TimeslotSession value, $Res Function(_$TimeslotSession) then) =
+      __$$TimeslotSessionCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {String uuid,
+      String title,
+      DateTime startsAt,
+      int lengthMin,
+      Track track,
+      String? abstract});
+
+  $TrackCopyWith<$Res> get track;
+}
+
+/// @nodoc
+class __$$TimeslotSessionCopyWithImpl<$Res>
+    extends _$SessionCopyWithImpl<$Res, _$TimeslotSession>
+    implements _$$TimeslotSessionCopyWith<$Res> {
+  __$$TimeslotSessionCopyWithImpl(
+      _$TimeslotSession _value, $Res Function(_$TimeslotSession) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uuid = null,
+    Object? title = null,
+    Object? startsAt = null,
+    Object? lengthMin = null,
+    Object? track = null,
+    Object? abstract = freezed,
+  }) {
+    return _then(_$TimeslotSession(
+      uuid: null == uuid
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      lengthMin: null == lengthMin
+          ? _value.lengthMin
+          : lengthMin // ignore: cast_nullable_to_non_nullable
+              as int,
+      track: null == track
+          ? _value.track
+          : track // ignore: cast_nullable_to_non_nullable
+              as Track,
+      abstract: freezed == abstract
+          ? _value.abstract
+          : abstract // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $TrackCopyWith<$Res> get track {
+    return $TrackCopyWith<$Res>(_value.track, (value) {
+      return _then(_value.copyWith(track: value));
+    });
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _$TimeslotSession implements TimeslotSession {
+  const _$TimeslotSession(
+      {required this.uuid,
+      required this.title,
+      required this.startsAt,
+      required this.lengthMin,
+      required this.track,
+      this.abstract,
+      final String? $type})
+      : $type = $type ?? 'timeslot';
+
+  factory _$TimeslotSession.fromJson(Map<String, dynamic> json) =>
+      _$$TimeslotSessionFromJson(json);
+
+  @override
+  final String uuid;
+  @override
+  final String title;
+  @override
+  final DateTime startsAt;
+  @override
+  final int lengthMin;
+  @override
+  final Track track;
+  @override
+  final String? abstract;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Session.timeslot(uuid: $uuid, title: $title, startsAt: $startsAt, lengthMin: $lengthMin, track: $track, abstract: $abstract)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TimeslotSession &&
+            (identical(other.uuid, uuid) || other.uuid == uuid) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.startsAt, startsAt) ||
+                other.startsAt == startsAt) &&
+            (identical(other.lengthMin, lengthMin) ||
+                other.lengthMin == lengthMin) &&
+            (identical(other.track, track) || other.track == track) &&
+            (identical(other.abstract, abstract) ||
+                other.abstract == abstract));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, uuid, title, startsAt, lengthMin, track, abstract);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TimeslotSessionCopyWith<_$TimeslotSession> get copyWith =>
+      __$$TimeslotSessionCopyWithImpl<_$TimeslotSession>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)
+        timeslot,
+    required TResult Function(
+            String uuid,
+            String url,
+            String title,
+            String abstract,
+            Track track,
+            DateTime startsAt,
+            int lengthMin,
+            Speaker speaker)
+        talk,
+    required TResult Function() lunch,
+  }) {
+    return timeslot(uuid, title, startsAt, lengthMin, track, abstract);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult? Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult? Function()? lunch,
+  }) {
+    return timeslot?.call(uuid, title, startsAt, lengthMin, track, abstract);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult Function()? lunch,
+    required TResult orElse(),
+  }) {
+    if (timeslot != null) {
+      return timeslot(uuid, title, startsAt, lengthMin, track, abstract);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TimeslotSession value) timeslot,
+    required TResult Function(TalkSession value) talk,
+    required TResult Function(LunchSession value) lunch,
+  }) {
+    return timeslot(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TimeslotSession value)? timeslot,
+    TResult? Function(TalkSession value)? talk,
+    TResult? Function(LunchSession value)? lunch,
+  }) {
+    return timeslot?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TimeslotSession value)? timeslot,
+    TResult Function(TalkSession value)? talk,
+    TResult Function(LunchSession value)? lunch,
+    required TResult orElse(),
+  }) {
+    if (timeslot != null) {
+      return timeslot(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TimeslotSessionToJson(
+      this,
+    );
+  }
+}
+
+abstract class TimeslotSession implements Session {
+  const factory TimeslotSession(
+      {required final String uuid,
+      required final String title,
+      required final DateTime startsAt,
+      required final int lengthMin,
+      required final Track track,
+      final String? abstract}) = _$TimeslotSession;
+
+  factory TimeslotSession.fromJson(Map<String, dynamic> json) =
+      _$TimeslotSession.fromJson;
+
+  String get uuid;
+  String get title;
+  DateTime get startsAt;
+  int get lengthMin;
+  Track get track;
+  String? get abstract;
+  @JsonKey(ignore: true)
+  _$$TimeslotSessionCopyWith<_$TimeslotSession> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$TalkSessionCopyWith<$Res> {
+  factory _$$TalkSessionCopyWith(
+          _$TalkSession value, $Res Function(_$TalkSession) then) =
+      __$$TalkSessionCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {String uuid,
+      String url,
+      String title,
+      String abstract,
+      Track track,
+      DateTime startsAt,
+      int lengthMin,
+      Speaker speaker});
+
+  $TrackCopyWith<$Res> get track;
+  $SpeakerCopyWith<$Res> get speaker;
+}
+
+/// @nodoc
+class __$$TalkSessionCopyWithImpl<$Res>
+    extends _$SessionCopyWithImpl<$Res, _$TalkSession>
+    implements _$$TalkSessionCopyWith<$Res> {
+  __$$TalkSessionCopyWithImpl(
+      _$TalkSession _value, $Res Function(_$TalkSession) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uuid = null,
+    Object? url = null,
+    Object? title = null,
+    Object? abstract = null,
+    Object? track = null,
+    Object? startsAt = null,
+    Object? lengthMin = null,
+    Object? speaker = null,
+  }) {
+    return _then(_$TalkSession(
+      uuid: null == uuid
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      abstract: null == abstract
+          ? _value.abstract
+          : abstract // ignore: cast_nullable_to_non_nullable
+              as String,
+      track: null == track
+          ? _value.track
+          : track // ignore: cast_nullable_to_non_nullable
+              as Track,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      lengthMin: null == lengthMin
+          ? _value.lengthMin
+          : lengthMin // ignore: cast_nullable_to_non_nullable
+              as int,
+      speaker: null == speaker
+          ? _value.speaker
+          : speaker // ignore: cast_nullable_to_non_nullable
+              as Speaker,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $TrackCopyWith<$Res> get track {
+    return $TrackCopyWith<$Res>(_value.track, (value) {
+      return _then(_value.copyWith(track: value));
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SpeakerCopyWith<$Res> get speaker {
+    return $SpeakerCopyWith<$Res>(_value.speaker, (value) {
+      return _then(_value.copyWith(speaker: value));
+    });
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _$TalkSession implements TalkSession {
+  const _$TalkSession(
+      {required this.uuid,
+      required this.url,
+      required this.title,
+      required this.abstract,
+      required this.track,
+      required this.startsAt,
+      required this.lengthMin,
+      required this.speaker,
+      final String? $type})
+      : $type = $type ?? 'talk';
+
+  factory _$TalkSession.fromJson(Map<String, dynamic> json) =>
+      _$$TalkSessionFromJson(json);
+
+  @override
+  final String uuid;
+  @override
+  final String url;
+  @override
+  final String title;
+  @override
+  final String abstract;
+  @override
+  final Track track;
+  @override
+  final DateTime startsAt;
+  @override
+  final int lengthMin;
+  @override
+  final Speaker speaker;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Session.talk(uuid: $uuid, url: $url, title: $title, abstract: $abstract, track: $track, startsAt: $startsAt, lengthMin: $lengthMin, speaker: $speaker)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TalkSession &&
+            (identical(other.uuid, uuid) || other.uuid == uuid) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.abstract, abstract) ||
+                other.abstract == abstract) &&
+            (identical(other.track, track) || other.track == track) &&
+            (identical(other.startsAt, startsAt) ||
+                other.startsAt == startsAt) &&
+            (identical(other.lengthMin, lengthMin) ||
+                other.lengthMin == lengthMin) &&
+            (identical(other.speaker, speaker) || other.speaker == speaker));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, uuid, url, title, abstract,
+      track, startsAt, lengthMin, speaker);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TalkSessionCopyWith<_$TalkSession> get copyWith =>
+      __$$TalkSessionCopyWithImpl<_$TalkSession>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)
+        timeslot,
+    required TResult Function(
+            String uuid,
+            String url,
+            String title,
+            String abstract,
+            Track track,
+            DateTime startsAt,
+            int lengthMin,
+            Speaker speaker)
+        talk,
+    required TResult Function() lunch,
+  }) {
+    return talk(
+        uuid, url, title, abstract, track, startsAt, lengthMin, speaker);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult? Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult? Function()? lunch,
+  }) {
+    return talk?.call(
+        uuid, url, title, abstract, track, startsAt, lengthMin, speaker);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult Function()? lunch,
+    required TResult orElse(),
+  }) {
+    if (talk != null) {
+      return talk(
+          uuid, url, title, abstract, track, startsAt, lengthMin, speaker);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TimeslotSession value) timeslot,
+    required TResult Function(TalkSession value) talk,
+    required TResult Function(LunchSession value) lunch,
+  }) {
+    return talk(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TimeslotSession value)? timeslot,
+    TResult? Function(TalkSession value)? talk,
+    TResult? Function(LunchSession value)? lunch,
+  }) {
+    return talk?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TimeslotSession value)? timeslot,
+    TResult Function(TalkSession value)? talk,
+    TResult Function(LunchSession value)? lunch,
+    required TResult orElse(),
+  }) {
+    if (talk != null) {
+      return talk(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TalkSessionToJson(
+      this,
+    );
+  }
+}
+
+abstract class TalkSession implements Session {
+  const factory TalkSession(
+      {required final String uuid,
+      required final String url,
+      required final String title,
+      required final String abstract,
+      required final Track track,
+      required final DateTime startsAt,
+      required final int lengthMin,
+      required final Speaker speaker}) = _$TalkSession;
+
+  factory TalkSession.fromJson(Map<String, dynamic> json) =
+      _$TalkSession.fromJson;
+
+  String get uuid;
+  String get url;
+  String get title;
+  String get abstract;
+  Track get track;
+  DateTime get startsAt;
+  int get lengthMin;
+  Speaker get speaker;
+  @JsonKey(ignore: true)
+  _$$TalkSessionCopyWith<_$TalkSession> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$LunchSessionCopyWith<$Res> {
+  factory _$$LunchSessionCopyWith(
+          _$LunchSession value, $Res Function(_$LunchSession) then) =
+      __$$LunchSessionCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$LunchSessionCopyWithImpl<$Res>
+    extends _$SessionCopyWithImpl<$Res, _$LunchSession>
+    implements _$$LunchSessionCopyWith<$Res> {
+  __$$LunchSessionCopyWithImpl(
+      _$LunchSession _value, $Res Function(_$LunchSession) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$LunchSession implements LunchSession {
+  const _$LunchSession({final String? $type}) : $type = $type ?? 'lunch';
+
+  factory _$LunchSession.fromJson(Map<String, dynamic> json) =>
+      _$$LunchSessionFromJson(json);
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Session.lunch()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$LunchSession);
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)
+        timeslot,
+    required TResult Function(
+            String uuid,
+            String url,
+            String title,
+            String abstract,
+            Track track,
+            DateTime startsAt,
+            int lengthMin,
+            Speaker speaker)
+        talk,
+    required TResult Function() lunch,
+  }) {
+    return lunch();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult? Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult? Function()? lunch,
+  }) {
+    return lunch?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String uuid, String title, DateTime startsAt,
+            int lengthMin, Track track, String? abstract)?
+        timeslot,
+    TResult Function(String uuid, String url, String title, String abstract,
+            Track track, DateTime startsAt, int lengthMin, Speaker speaker)?
+        talk,
+    TResult Function()? lunch,
+    required TResult orElse(),
+  }) {
+    if (lunch != null) {
+      return lunch();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TimeslotSession value) timeslot,
+    required TResult Function(TalkSession value) talk,
+    required TResult Function(LunchSession value) lunch,
+  }) {
+    return lunch(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TimeslotSession value)? timeslot,
+    TResult? Function(TalkSession value)? talk,
+    TResult? Function(LunchSession value)? lunch,
+  }) {
+    return lunch?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TimeslotSession value)? timeslot,
+    TResult Function(TalkSession value)? talk,
+    TResult Function(LunchSession value)? lunch,
+    required TResult orElse(),
+  }) {
+    if (lunch != null) {
+      return lunch(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$LunchSessionToJson(
+      this,
+    );
+  }
+}
+
+abstract class LunchSession implements Session {
+  const factory LunchSession() = _$LunchSession;
+
+  factory LunchSession.fromJson(Map<String, dynamic> json) =
+      _$LunchSession.fromJson;
+}

--- a/lib/features/session/model/session.g.dart
+++ b/lib/features/session/model/session.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TimeslotSession _$$TimeslotSessionFromJson(Map<String, dynamic> json) =>
+    _$TimeslotSession(
+      uuid: json['uuid'] as String,
+      title: json['title'] as String,
+      startsAt: DateTime.parse(json['starts_at'] as String),
+      lengthMin: json['length_min'] as int,
+      track: Track.fromJson(json['track'] as Map<String, dynamic>),
+      abstract: json['abstract'] as String?,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$TimeslotSessionToJson(_$TimeslotSession instance) =>
+    <String, dynamic>{
+      'uuid': instance.uuid,
+      'title': instance.title,
+      'starts_at': instance.startsAt.toIso8601String(),
+      'length_min': instance.lengthMin,
+      'track': instance.track,
+      'abstract': instance.abstract,
+      'type': instance.$type,
+    };
+
+_$TalkSession _$$TalkSessionFromJson(Map<String, dynamic> json) =>
+    _$TalkSession(
+      uuid: json['uuid'] as String,
+      url: json['url'] as String,
+      title: json['title'] as String,
+      abstract: json['abstract'] as String,
+      track: Track.fromJson(json['track'] as Map<String, dynamic>),
+      startsAt: DateTime.parse(json['starts_at'] as String),
+      lengthMin: json['length_min'] as int,
+      speaker: Speaker.fromJson(json['speaker'] as Map<String, dynamic>),
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$TalkSessionToJson(_$TalkSession instance) =>
+    <String, dynamic>{
+      'uuid': instance.uuid,
+      'url': instance.url,
+      'title': instance.title,
+      'abstract': instance.abstract,
+      'track': instance.track,
+      'starts_at': instance.startsAt.toIso8601String(),
+      'length_min': instance.lengthMin,
+      'speaker': instance.speaker,
+      'type': instance.$type,
+    };
+
+_$LunchSession _$$LunchSessionFromJson(Map<String, dynamic> json) =>
+    _$LunchSession(
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$LunchSessionToJson(_$LunchSession instance) =>
+    <String, dynamic>{
+      'type': instance.$type,
+    };

--- a/lib/features/session/model/speaker.dart
+++ b/lib/features/session/model/speaker.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'speaker.freezed.dart';
+part 'speaker.g.dart';
+
+@freezed
+class Speaker with _$Speaker {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory Speaker({
+    required String name,
+    required String avatarUrl,
+    String? twitter,
+  }) = _Speaker;
+
+  factory Speaker.fromJson(Map<String, dynamic> json) =>
+      _$SpeakerFromJson(json);
+}

--- a/lib/features/session/model/speaker.freezed.dart
+++ b/lib/features/session/model/speaker.freezed.dart
@@ -1,0 +1,183 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'speaker.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Speaker _$SpeakerFromJson(Map<String, dynamic> json) {
+  return _Speaker.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Speaker {
+  String get name => throw _privateConstructorUsedError;
+  String get avatarUrl => throw _privateConstructorUsedError;
+  String? get twitter => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SpeakerCopyWith<Speaker> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SpeakerCopyWith<$Res> {
+  factory $SpeakerCopyWith(Speaker value, $Res Function(Speaker) then) =
+      _$SpeakerCopyWithImpl<$Res, Speaker>;
+  @useResult
+  $Res call({String name, String avatarUrl, String? twitter});
+}
+
+/// @nodoc
+class _$SpeakerCopyWithImpl<$Res, $Val extends Speaker>
+    implements $SpeakerCopyWith<$Res> {
+  _$SpeakerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? avatarUrl = null,
+    Object? twitter = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarUrl: null == avatarUrl
+          ? _value.avatarUrl
+          : avatarUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      twitter: freezed == twitter
+          ? _value.twitter
+          : twitter // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_SpeakerCopyWith<$Res> implements $SpeakerCopyWith<$Res> {
+  factory _$$_SpeakerCopyWith(
+          _$_Speaker value, $Res Function(_$_Speaker) then) =
+      __$$_SpeakerCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, String avatarUrl, String? twitter});
+}
+
+/// @nodoc
+class __$$_SpeakerCopyWithImpl<$Res>
+    extends _$SpeakerCopyWithImpl<$Res, _$_Speaker>
+    implements _$$_SpeakerCopyWith<$Res> {
+  __$$_SpeakerCopyWithImpl(_$_Speaker _value, $Res Function(_$_Speaker) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? avatarUrl = null,
+    Object? twitter = freezed,
+  }) {
+    return _then(_$_Speaker(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarUrl: null == avatarUrl
+          ? _value.avatarUrl
+          : avatarUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      twitter: freezed == twitter
+          ? _value.twitter
+          : twitter // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _$_Speaker implements _Speaker {
+  const _$_Speaker({required this.name, required this.avatarUrl, this.twitter});
+
+  factory _$_Speaker.fromJson(Map<String, dynamic> json) =>
+      _$$_SpeakerFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final String avatarUrl;
+  @override
+  final String? twitter;
+
+  @override
+  String toString() {
+    return 'Speaker(name: $name, avatarUrl: $avatarUrl, twitter: $twitter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Speaker &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.avatarUrl, avatarUrl) ||
+                other.avatarUrl == avatarUrl) &&
+            (identical(other.twitter, twitter) || other.twitter == twitter));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, avatarUrl, twitter);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SpeakerCopyWith<_$_Speaker> get copyWith =>
+      __$$_SpeakerCopyWithImpl<_$_Speaker>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_SpeakerToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Speaker implements Speaker {
+  const factory _Speaker(
+      {required final String name,
+      required final String avatarUrl,
+      final String? twitter}) = _$_Speaker;
+
+  factory _Speaker.fromJson(Map<String, dynamic> json) = _$_Speaker.fromJson;
+
+  @override
+  String get name;
+  @override
+  String get avatarUrl;
+  @override
+  String? get twitter;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SpeakerCopyWith<_$_Speaker> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/session/model/speaker.g.dart
+++ b/lib/features/session/model/speaker.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'speaker.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Speaker _$$_SpeakerFromJson(Map<String, dynamic> json) => _$_Speaker(
+      name: json['name'] as String,
+      avatarUrl: json['avatar_url'] as String,
+      twitter: json['twitter'] as String?,
+    );
+
+Map<String, dynamic> _$$_SpeakerToJson(_$_Speaker instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'avatar_url': instance.avatarUrl,
+      'twitter': instance.twitter,
+    };

--- a/lib/features/session/model/track.dart
+++ b/lib/features/session/model/track.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'track.freezed.dart';
+part 'track.g.dart';
+
+@freezed
+class Track with _$Track {
+  const factory Track({
+    required String name,
+    required int sort,
+  }) = _Track;
+
+  factory Track.fromJson(Map<String, dynamic> json) => _$TrackFromJson(json);
+}

--- a/lib/features/session/model/track.freezed.dart
+++ b/lib/features/session/model/track.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'track.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Track _$TrackFromJson(Map<String, dynamic> json) {
+  return _Track.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Track {
+  String get name => throw _privateConstructorUsedError;
+  int get sort => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TrackCopyWith<Track> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TrackCopyWith<$Res> {
+  factory $TrackCopyWith(Track value, $Res Function(Track) then) =
+      _$TrackCopyWithImpl<$Res, Track>;
+  @useResult
+  $Res call({String name, int sort});
+}
+
+/// @nodoc
+class _$TrackCopyWithImpl<$Res, $Val extends Track>
+    implements $TrackCopyWith<$Res> {
+  _$TrackCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? sort = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      sort: null == sort
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_TrackCopyWith<$Res> implements $TrackCopyWith<$Res> {
+  factory _$$_TrackCopyWith(_$_Track value, $Res Function(_$_Track) then) =
+      __$$_TrackCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, int sort});
+}
+
+/// @nodoc
+class __$$_TrackCopyWithImpl<$Res> extends _$TrackCopyWithImpl<$Res, _$_Track>
+    implements _$$_TrackCopyWith<$Res> {
+  __$$_TrackCopyWithImpl(_$_Track _value, $Res Function(_$_Track) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? sort = null,
+  }) {
+    return _then(_$_Track(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      sort: null == sort
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Track implements _Track {
+  const _$_Track({required this.name, required this.sort});
+
+  factory _$_Track.fromJson(Map<String, dynamic> json) =>
+      _$$_TrackFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final int sort;
+
+  @override
+  String toString() {
+    return 'Track(name: $name, sort: $sort)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Track &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.sort, sort) || other.sort == sort));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, sort);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_TrackCopyWith<_$_Track> get copyWith =>
+      __$$_TrackCopyWithImpl<_$_Track>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_TrackToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Track implements Track {
+  const factory _Track({required final String name, required final int sort}) =
+      _$_Track;
+
+  factory _Track.fromJson(Map<String, dynamic> json) = _$_Track.fromJson;
+
+  @override
+  String get name;
+  @override
+  int get sort;
+  @override
+  @JsonKey(ignore: true)
+  _$$_TrackCopyWith<_$_Track> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/session/model/track.g.dart
+++ b/lib/features/session/model/track.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'track.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Track _$$_TrackFromJson(Map<String, dynamic> json) => _$_Track(
+      name: json['name'] as String,
+      sort: json['sort'] as int,
+    );
+
+Map<String, dynamic> _$$_TrackToJson(_$_Track instance) => <String, dynamic>{
+      'name': instance.name,
+      'sort': instance.sort,
+    };


### PR DESCRIPTION
## Issue

- [セッション一覧ページの設計・実装 · Issue #166 · FlutterKaigi/TasksBoard](https://github.com/FlutterKaigi/TasksBoard/issues/166)

## Overview (Required)

- セッション関連のモデルを追加
  - Fortee APIを利用して得た結果をもとに作成しています