### PR TITLE
Improve: HeroSectionTwitterにMouseRegionを追加

### DIFF
--- a/lib/features/hero/ui/hero_section_twitter.dart
+++ b/lib/features/hero/ui/hero_section_twitter.dart
@@ -35,56 +35,61 @@ class HeroSectionTwitter extends StatelessWidget {
         uri: Uri.parse(url),
         target: LinkTarget.blank,
         builder: (context, openLink) {
-          return GestureDetector(
-            onTap: openLink,
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Container(
-                width: isMobile ? 358 : 744,
-                padding: EdgeInsets.symmetric(
-                  horizontal: 30,
-                  vertical: isMobile ? 8 : 12,
-                ),
-                decoration: BoxDecoration(
-                  color: backgroundColor,
-                  borderRadius: BorderRadius.circular(100),
-                  border: Border.all(
-                    color: baselineColorScheme.ref.primary.primary90,
-                    width: 2,
+          return MouseRegion(
+            cursor: SystemMouseCursors.click,
+            hitTestBehavior: HitTestBehavior.deferToChild,
+            child: GestureDetector(
+              onTap: openLink,
+              behavior: HitTestBehavior.deferToChild,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Container(
+                  width: isMobile ? 358 : 744,
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 30,
+                    vertical: isMobile ? 8 : 12,
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: baselineColorScheme.white.withOpacity(0.35),
-                      offset: const Offset(0, 2),
-                      blurRadius: 16,
+                  decoration: BoxDecoration(
+                    color: backgroundColor,
+                    borderRadius: BorderRadius.circular(100),
+                    border: Border.all(
+                      color: baselineColorScheme.ref.primary.primary90,
+                      width: 2,
                     ),
-                  ],
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(
-                      width: 40,
-                      height: 40,
-                      child: SvgPicture.asset(
-                        icon,
-                        colorFilter: ColorFilter.mode(
-                          iconColor,
-                          BlendMode.srcIn,
+                    boxShadow: [
+                      BoxShadow(
+                        color: baselineColorScheme.white.withOpacity(0.35),
+                        offset: const Offset(0, 2),
+                        blurRadius: 16,
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 40,
+                        height: 40,
+                        child: SvgPicture.asset(
+                          icon,
+                          colorFilter: ColorFilter.mode(
+                            iconColor,
+                            BlendMode.srcIn,
+                          ),
                         ),
                       ),
-                    ),
-                    Spaces.horizontal_20,
-                    Text(
-                      title,
-                      style: titleTextStyle,
-                    ),
-                    if (isMobile) const SizedBox.shrink() else const Spacer(),
-                    Text(
-                      subTitle,
-                      style: subTitleTextStyle,
-                    ),
-                  ],
+                      Spaces.horizontal_20,
+                      Text(
+                        title,
+                        style: titleTextStyle,
+                      ),
+                      if (isMobile) const SizedBox.shrink() else const Spacer(),
+                      Text(
+                        subTitle,
+                        style: subTitleTextStyle,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Issue

- close #144 

## Overview (Required)

- トップページの公式Twitter/ハッシュタグボタンをHoverしたときにポインタが変化するように変更
- 同ボタンの角丸部分はHover/クリック判定がないように

## Links

- 

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/FlutterKaigi/2023/assets/31440714/7e5ea660-1700-4788-84c1-2de0fb32362c" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/31440714/8e99377c-b22b-454b-af67-571f8f759f0a" width="300" /> |
