### PR TITLE
SectionHeader のグラデーションを外から渡せるように変更

### DIFF
--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -2,7 +2,7 @@ import 'package:confwebsite2023/core/theme.dart';
 import 'package:flutter/material.dart';
 
 /// A section header with a gradient.
-class SectionHeader extends StatelessWidget {
+final class SectionHeader extends StatelessWidget {
   const SectionHeader({
     required this.text,
     required this.style,

--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -1,4 +1,3 @@
-import 'package:confwebsite2023/core/theme.dart';
 import 'package:flutter/material.dart';
 
 /// A section header with a gradient.
@@ -6,6 +5,7 @@ final class SectionHeader extends StatelessWidget {
   const SectionHeader({
     required this.text,
     required this.style,
+    required this.gradient,
     super.key,
   });
 
@@ -17,6 +17,8 @@ final class SectionHeader extends StatelessWidget {
 
   final TextStyle style;
 
+  final Gradient gradient;
+
   @override
   Widget build(BuildContext context) {
     return Transform.translate(
@@ -26,7 +28,7 @@ final class SectionHeader extends StatelessWidget {
         shaderCallback: (Rect bounds) {
           // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
           final textSize = _getTextSize(maxWidth: bounds.width);
-          return GradientConstant.accent.primary.createShader(
+          return gradient.createShader(
             Rect.fromLTWH(0, 0, textSize.width, textSize.height),
           );
         },

--- a/lib/core/components/wanted.dart
+++ b/lib/core/components/wanted.dart
@@ -1,6 +1,6 @@
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/components/section_header.dart';
-import 'package:confwebsite2023/core/theme/dimension.dart';
+import 'package:confwebsite2023/core/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -80,6 +80,7 @@ class WantedDesktop extends StatelessWidget {
             fontWeight: FontWeight.w700,
             height: 1.1,
           ),
+          gradient: GradientConstant.accent.primary,
         ),
         Spaces.vertical_24,
         Row(
@@ -190,6 +191,7 @@ class WantedMobile extends StatelessWidget {
             fontWeight: FontWeight.w700,
             height: 1.1,
           ),
+          gradient: GradientConstant.accent.primary,
         ),
         Spaces.vertical_24,
         Column(

--- a/lib/features/staff/ui/staff_header.dart
+++ b/lib/features/staff/ui/staff_header.dart
@@ -1,6 +1,6 @@
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/components/section_header.dart';
-import 'package:confwebsite2023/core/theme/app_text_style.dart';
+import 'package:confwebsite2023/core/theme.dart';
 import 'package:flutter/material.dart';
 
 class StaffHeader extends StatelessWidget {
@@ -12,10 +12,12 @@ class StaffHeader extends StatelessWidget {
       largeWidget: SectionHeader(
         text: 'Staff',
         style: AppTextStyle.pcHeading1,
+        gradient: GradientConstant.accent.primary,
       ),
       smallWidget: SectionHeader(
         text: 'Staff',
         style: AppTextStyle.spHeading1,
+        gradient: GradientConstant.accent.primary,
       ),
     );
   }


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER

## Overview (Required)

- SectionHeader のグラデーションを外から渡せるように変更します。
  - スポンサー用のコンポーネントを作成するにあたり、外から渡したほうが使いまわしやすいことが判明したことによる対応となります。

## Links

- 

## Screenshot

見た目の変更はありません。
