### PR TITLE
SectionHeader のスタート位置調整可否をプロパティとして持つよう変更

### DIFF
--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -6,11 +6,14 @@ final class SectionHeader extends StatelessWidget {
     required this.text,
     required this.style,
     required this.gradient,
+    this.isNotTranslate = false,
     super.key,
   });
 
   /// ブラーのぼかし範囲
   static const double _blurRadius = 20;
+
+  final bool isNotTranslate;
 
   /// The text to display.
   final String text;
@@ -21,29 +24,35 @@ final class SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Transform.translate(
-      // NOTE: ブラーのぼかし範囲を考慮してオフセットを設定する
-      offset: const Offset(-SectionHeader._blurRadius, 0),
-      child: ShaderMask(
-        shaderCallback: (Rect bounds) {
-          // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
-          final textSize = _getTextSize(maxWidth: bounds.width);
-          return gradient.createShader(
-            Rect.fromLTWH(0, 0, textSize.width, textSize.height),
-          );
-        },
-        blendMode: BlendMode.srcIn,
-        child: Padding(
-          // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
-          padding: const EdgeInsets.all(_blurRadius),
-          child: Text(
-            text,
-            style: style.copyWith(
-              color: Colors.white,
-            ),
+    final component = ShaderMask(
+      shaderCallback: (Rect bounds) {
+        // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
+        final textSize = _getTextSize(maxWidth: bounds.width);
+        return gradient.createShader(
+          Rect.fromLTWH(0, 0, textSize.width, textSize.height),
+        );
+      },
+      blendMode: BlendMode.srcIn,
+      child: Padding(
+        // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
+        padding: const EdgeInsets.all(_blurRadius),
+        child: Text(
+          text,
+          style: style.copyWith(
+            color: Colors.white,
           ),
         ),
       ),
+    );
+
+    if (isNotTranslate) {
+      return component;
+    }
+
+    return Transform.translate(
+      // NOTE: ブラーのぼかし範囲を考慮してオフセットを設定する
+      offset: const Offset(-SectionHeader._blurRadius, 0),
+      child: component,
     );
   }
 


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER

## Overview (Required)

- SectionHeader のスタート位置調整可否をプロパティとして持つよう変更します
  - デフォルトのは既存と同じ動作にすることでデグレしないよう考慮しています

## Why

- 各スポンサーランクやアプリケーションなどのヘッダーは中央寄せの想定のため `translate` しないほうがよいパターンが出てきたためです

## Links

- 

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
