### PR TITLE
:lipstick: Adjust bottom padding of StaffTable

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -145,8 +145,12 @@ class _MainPageBody extends StatelessWidget {
               ),
             ),
             SliverPadding(
-              padding:
-                  EdgeInsets.symmetric(horizontal: horizontal, vertical: 16),
+              padding: EdgeInsets.only(
+                left: horizontal,
+                right: horizontal,
+                top: 16,
+                bottom: 200,
+              ),
               sliver: const StaffTable(),
             ),
             const SliverToBoxAdapter(


### PR DESCRIPTION
## Issue

- close https://github.com/FlutterKaigi/2023/issues/139

## Overview (Required)

- Adjust bottom padding of StaffTable from 16 to 200

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/FlutterKaigi/2023/assets/88303689/637e7f19-503a-492a-be29-c68da927e7e2" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/88303689/7c44a254-4d0d-4021-8de9-51f961f5f029" width="300" /> |
