### PR TITLE
fix: Access Section の下のパディング修正

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -152,14 +152,15 @@ class _MainPageBody extends StatelessWidget {
                 key: staffSectionKey,
               ),
             ),
+            const SliverToBoxAdapter(
+              child: Spaces.vertical_16,
+            ),
             SliverPadding(
-              padding: EdgeInsets.only(
-                left: horizontal,
-                right: horizontal,
-                top: 16,
-                bottom: 200,
-              ),
+              padding: padding,
               sliver: const StaffTable(),
+            ),
+            const SliverToBoxAdapter(
+              child: Spaces.vertical_200,
             ),
             const SliverToBoxAdapter(
               child: Footer(),

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -143,6 +143,9 @@ class _MainPageBody extends StatelessWidget {
               padding: padding,
               child: const AccessWidget(),
             ),
+            const SliverToBoxAdapter(
+              child: Spaces.vertical_200,
+            ),
             _Sliver(
               padding: padding,
               child: StaffHeader(


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

Access Section の下に 200px のパディングを追加しました。
ついでに、可能な限り const を使うように一部修正しました。

## Links

- https://www.figma.com/file/LsVB4KlIMXD4Z1FfB8KyuU/FlutterKaigi-Web-2023?type=design&node-id=30-1309&mode=design&t=r8UhkJpSPXKBu5zB-0

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img width="973" alt="スクリーンショット 2023-09-17 0 37 46" src="https://github.com/FlutterKaigi/2023/assets/32213113/31e4b107-2a75-4c3d-b7b0-2da7afe970fb"> | <img width="973" alt="スクリーンショット 2023-09-17 0 36 58" src="https://github.com/FlutterKaigi/2023/assets/32213113/ac7c5c02-51d3-42ce-8d58-f8d9bf55aeac"> |