### PR TITLE
スポンサー関連のヘッダーウィジェットを追加

### DIFF
--- a/lib/features/sponsor/ui/sponsor_rank_header.dart
+++ b/lib/features/sponsor/ui/sponsor_rank_header.dart
@@ -1,0 +1,59 @@
+import 'package:confwebsite2023/core/components/section_header.dart';
+import 'package:confwebsite2023/core/theme.dart';
+import 'package:flutter/material.dart';
+
+final class SponsorRankHeader extends StatelessWidget {
+  SponsorRankHeader.platinum({
+    required String text,
+    required TextStyle style,
+  }) : this._(
+          text: text,
+          style: style,
+          gradient: GradientConstant.sponsor.platinum,
+        );
+
+  SponsorRankHeader.gold({
+    required String text,
+    required TextStyle style,
+  }) : this._(
+          text: text,
+          style: style,
+          gradient: GradientConstant.sponsor.gold,
+        );
+
+  SponsorRankHeader.silver({
+    required String text,
+    required TextStyle style,
+  }) : this._(
+          text: text,
+          style: style,
+          gradient: GradientConstant.sponsor.silver,
+        );
+
+  SponsorRankHeader._({
+    required this.text,
+    required TextStyle style,
+    required this.gradient,
+  }) : style = style.copyWith(
+          shadows: [
+            Shadow(
+              color: gradient.colors.first.withOpacity(0.25),
+              blurRadius: 10,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        );
+
+  final String text;
+
+  final TextStyle style;
+
+  final Gradient gradient;
+
+  @override
+  Widget build(BuildContext context) => SectionHeader.centerAlignment(
+        text: text,
+        style: style,
+        gradient: gradient,
+      );
+}

--- a/lib/features/sponsor/ui/sponsors_header.dart
+++ b/lib/features/sponsor/ui/sponsors_header.dart
@@ -1,0 +1,21 @@
+import 'package:confwebsite2023/core/components/section_header.dart';
+import 'package:confwebsite2023/core/theme.dart';
+import 'package:flutter/material.dart';
+
+final class SponsorsHeader extends StatelessWidget {
+  const SponsorsHeader({
+    required this.style,
+    super.key,
+  });
+
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return SectionHeader.leftAlignment(
+      text: 'Sponsors',
+      style: style,
+      gradient: GradientConstant.accent.primary,
+    );
+  }
+}


### PR DESCRIPTION
## Issue

- [スポンサーセクション（第2段階）の設計・実装 · Issue #164 · FlutterKaigi/TasksBoard](https://github.com/FlutterKaigi/TasksBoard/issues/164)

## Overview (Required)

- スポンサー関連のヘッダーウィジェットを追加します
  - Sponsors ヘッダー
  - 各種ランクヘッダー
    - Platinum
    - Gold
    - Silver

## Links

- 

## Screenshot

### Sponsors ヘッダー

<img src="https://github.com/FlutterKaigi/2023/assets/19267812/c87c6cad-d1b3-4c86-952a-551280acf897" width="400" />

### 各種ランクヘッダー

#### Platinum

<img src="https://github.com/FlutterKaigi/2023/assets/19267812/815bc039-1872-44d0-be9b-42e264f34866" width="400" />

#### Gold

<img src="https://github.com/FlutterKaigi/2023/assets/19267812/004fde86-7afd-4ef9-a86e-24c15caa6fff" width="400" />

#### Silver

<img src="https://github.com/FlutterKaigi/2023/assets/19267812/e347257e-6be5-4650-ae24-d8e56056a9fb" width="400" />

## Figma

https://www.figma.com/file/LsVB4KlIMXD4Z1FfB8KyuU/FlutterKaigi-Web-2023?type=design&node-id=30-1309&mode=design&t=ksUGq3frkGZZCq52-4