### PR TITLE
スポンサー関連のモデルを追加

### DIFF
--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -11,7 +11,7 @@ class Sponsor with _$Sponsor {
     required String displayName,
     required String url,
     required String logoAssetName,
-    required SponsorRank rank,
+    required SponsorPlan plan,
     required SponsorSession? session,
     @Default('') String introduction,
   }) = _Sponsor;

--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -9,7 +9,7 @@ class Sponsor with _$Sponsor {
     required String name,
     required String displayName,
     required String url,
-    required List<SponsorSession> sessions,
+    required SponsorSession? session,
     @Default('') String introduction,
   }) = _Sponsor;
 }

--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -1,3 +1,4 @@
+import 'package:confwebsite2023/features/sponsor/data/sponsor_rank.dart';
 import 'package:confwebsite2023/features/sponsor/data/sponsor_session.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -9,6 +10,7 @@ class Sponsor with _$Sponsor {
     required String name,
     required String displayName,
     required String url,
+    required SponsorRank rank,
     required SponsorSession? session,
     @Default('') String introduction,
   }) = _Sponsor;

--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: invalid_annotation_target
-
 import 'package:confwebsite2023/features/sponsor/data/sponsor_session.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:confwebsite2023/features/sponsor/data/sponsor_session.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sponsor.freezed.dart';
+
+@freezed
+class Sponsor with _$Sponsor {
+  const factory Sponsor({
+    required String name,
+    required String displayName,
+    required String url,
+    required List<SponsorSession> sessions,
+    @Default('') String introduction,
+  }) = _Sponsor;
+}

--- a/lib/features/sponsor/data/sponsor.dart
+++ b/lib/features/sponsor/data/sponsor.dart
@@ -10,6 +10,7 @@ class Sponsor with _$Sponsor {
     required String name,
     required String displayName,
     required String url,
+    required String logoAssetName,
     required SponsorRank rank,
     required SponsorSession? session,
     @Default('') String introduction,

--- a/lib/features/sponsor/data/sponsor.freezed.dart
+++ b/lib/features/sponsor/data/sponsor.freezed.dart
@@ -19,7 +19,7 @@ mixin _$Sponsor {
   String get name => throw _privateConstructorUsedError;
   String get displayName => throw _privateConstructorUsedError;
   String get url => throw _privateConstructorUsedError;
-  List<SponsorSession> get sessions => throw _privateConstructorUsedError;
+  SponsorSession? get session => throw _privateConstructorUsedError;
   String get introduction => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -35,8 +35,10 @@ abstract class $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
-      List<SponsorSession> sessions,
+      SponsorSession? session,
       String introduction});
+
+  $SponsorSessionCopyWith<$Res>? get session;
 }
 
 /// @nodoc
@@ -55,7 +57,7 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
-    Object? sessions = null,
+    Object? session = freezed,
     Object? introduction = null,
   }) {
     return _then(_value.copyWith(
@@ -71,15 +73,27 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
               as String,
-      sessions: null == sessions
-          ? _value.sessions
-          : sessions // ignore: cast_nullable_to_non_nullable
-              as List<SponsorSession>,
+      session: freezed == session
+          ? _value.session
+          : session // ignore: cast_nullable_to_non_nullable
+              as SponsorSession?,
       introduction: null == introduction
           ? _value.introduction
           : introduction // ignore: cast_nullable_to_non_nullable
               as String,
     ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SponsorSessionCopyWith<$Res>? get session {
+    if (_value.session == null) {
+      return null;
+    }
+
+    return $SponsorSessionCopyWith<$Res>(_value.session!, (value) {
+      return _then(_value.copyWith(session: value) as $Val);
+    });
   }
 }
 
@@ -94,8 +108,11 @@ abstract class _$$_SponsorCopyWith<$Res> implements $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
-      List<SponsorSession> sessions,
+      SponsorSession? session,
       String introduction});
+
+  @override
+  $SponsorSessionCopyWith<$Res>? get session;
 }
 
 /// @nodoc
@@ -111,7 +128,7 @@ class __$$_SponsorCopyWithImpl<$Res>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
-    Object? sessions = null,
+    Object? session = freezed,
     Object? introduction = null,
   }) {
     return _then(_$_Sponsor(
@@ -127,10 +144,10 @@ class __$$_SponsorCopyWithImpl<$Res>
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
               as String,
-      sessions: null == sessions
-          ? _value._sessions
-          : sessions // ignore: cast_nullable_to_non_nullable
-              as List<SponsorSession>,
+      session: freezed == session
+          ? _value.session
+          : session // ignore: cast_nullable_to_non_nullable
+              as SponsorSession?,
       introduction: null == introduction
           ? _value.introduction
           : introduction // ignore: cast_nullable_to_non_nullable
@@ -146,9 +163,8 @@ class _$_Sponsor implements _Sponsor {
       {required this.name,
       required this.displayName,
       required this.url,
-      required final List<SponsorSession> sessions,
-      this.introduction = ''})
-      : _sessions = sessions;
+      required this.session,
+      this.introduction = ''});
 
   @override
   final String name;
@@ -156,21 +172,15 @@ class _$_Sponsor implements _Sponsor {
   final String displayName;
   @override
   final String url;
-  final List<SponsorSession> _sessions;
   @override
-  List<SponsorSession> get sessions {
-    if (_sessions is EqualUnmodifiableListView) return _sessions;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_sessions);
-  }
-
+  final SponsorSession? session;
   @override
   @JsonKey()
   final String introduction;
 
   @override
   String toString() {
-    return 'Sponsor(name: $name, displayName: $displayName, url: $url, sessions: $sessions, introduction: $introduction)';
+    return 'Sponsor(name: $name, displayName: $displayName, url: $url, session: $session, introduction: $introduction)';
   }
 
   @override
@@ -182,14 +192,14 @@ class _$_Sponsor implements _Sponsor {
             (identical(other.displayName, displayName) ||
                 other.displayName == displayName) &&
             (identical(other.url, url) || other.url == url) &&
-            const DeepCollectionEquality().equals(other._sessions, _sessions) &&
+            (identical(other.session, session) || other.session == session) &&
             (identical(other.introduction, introduction) ||
                 other.introduction == introduction));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, name, displayName, url,
-      const DeepCollectionEquality().hash(_sessions), introduction);
+  int get hashCode =>
+      Object.hash(runtimeType, name, displayName, url, session, introduction);
 
   @JsonKey(ignore: true)
   @override
@@ -203,7 +213,7 @@ abstract class _Sponsor implements Sponsor {
       {required final String name,
       required final String displayName,
       required final String url,
-      required final List<SponsorSession> sessions,
+      required final SponsorSession? session,
       final String introduction}) = _$_Sponsor;
 
   @override
@@ -213,7 +223,7 @@ abstract class _Sponsor implements Sponsor {
   @override
   String get url;
   @override
-  List<SponsorSession> get sessions;
+  SponsorSession? get session;
   @override
   String get introduction;
   @override

--- a/lib/features/sponsor/data/sponsor.freezed.dart
+++ b/lib/features/sponsor/data/sponsor.freezed.dart
@@ -20,7 +20,7 @@ mixin _$Sponsor {
   String get displayName => throw _privateConstructorUsedError;
   String get url => throw _privateConstructorUsedError;
   String get logoAssetName => throw _privateConstructorUsedError;
-  SponsorRank get rank => throw _privateConstructorUsedError;
+  SponsorPlan get plan => throw _privateConstructorUsedError;
   SponsorSession? get session => throw _privateConstructorUsedError;
   String get introduction => throw _privateConstructorUsedError;
 
@@ -38,7 +38,7 @@ abstract class $SponsorCopyWith<$Res> {
       String displayName,
       String url,
       String logoAssetName,
-      SponsorRank rank,
+      SponsorPlan plan,
       SponsorSession? session,
       String introduction});
 
@@ -62,7 +62,7 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
     Object? displayName = null,
     Object? url = null,
     Object? logoAssetName = null,
-    Object? rank = null,
+    Object? plan = null,
     Object? session = freezed,
     Object? introduction = null,
   }) {
@@ -83,10 +83,10 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
           ? _value.logoAssetName
           : logoAssetName // ignore: cast_nullable_to_non_nullable
               as String,
-      rank: null == rank
-          ? _value.rank
-          : rank // ignore: cast_nullable_to_non_nullable
-              as SponsorRank,
+      plan: null == plan
+          ? _value.plan
+          : plan // ignore: cast_nullable_to_non_nullable
+              as SponsorPlan,
       session: freezed == session
           ? _value.session
           : session // ignore: cast_nullable_to_non_nullable
@@ -123,7 +123,7 @@ abstract class _$$_SponsorCopyWith<$Res> implements $SponsorCopyWith<$Res> {
       String displayName,
       String url,
       String logoAssetName,
-      SponsorRank rank,
+      SponsorPlan plan,
       SponsorSession? session,
       String introduction});
 
@@ -145,7 +145,7 @@ class __$$_SponsorCopyWithImpl<$Res>
     Object? displayName = null,
     Object? url = null,
     Object? logoAssetName = null,
-    Object? rank = null,
+    Object? plan = null,
     Object? session = freezed,
     Object? introduction = null,
   }) {
@@ -166,10 +166,10 @@ class __$$_SponsorCopyWithImpl<$Res>
           ? _value.logoAssetName
           : logoAssetName // ignore: cast_nullable_to_non_nullable
               as String,
-      rank: null == rank
-          ? _value.rank
-          : rank // ignore: cast_nullable_to_non_nullable
-              as SponsorRank,
+      plan: null == plan
+          ? _value.plan
+          : plan // ignore: cast_nullable_to_non_nullable
+              as SponsorPlan,
       session: freezed == session
           ? _value.session
           : session // ignore: cast_nullable_to_non_nullable
@@ -190,7 +190,7 @@ class _$_Sponsor implements _Sponsor {
       required this.displayName,
       required this.url,
       required this.logoAssetName,
-      required this.rank,
+      required this.plan,
       required this.session,
       this.introduction = ''});
 
@@ -203,7 +203,7 @@ class _$_Sponsor implements _Sponsor {
   @override
   final String logoAssetName;
   @override
-  final SponsorRank rank;
+  final SponsorPlan plan;
   @override
   final SponsorSession? session;
   @override
@@ -212,7 +212,7 @@ class _$_Sponsor implements _Sponsor {
 
   @override
   String toString() {
-    return 'Sponsor(name: $name, displayName: $displayName, url: $url, logoAssetName: $logoAssetName, rank: $rank, session: $session, introduction: $introduction)';
+    return 'Sponsor(name: $name, displayName: $displayName, url: $url, logoAssetName: $logoAssetName, plan: $plan, session: $session, introduction: $introduction)';
   }
 
   @override
@@ -226,7 +226,7 @@ class _$_Sponsor implements _Sponsor {
             (identical(other.url, url) || other.url == url) &&
             (identical(other.logoAssetName, logoAssetName) ||
                 other.logoAssetName == logoAssetName) &&
-            (identical(other.rank, rank) || other.rank == rank) &&
+            (identical(other.plan, plan) || other.plan == plan) &&
             (identical(other.session, session) || other.session == session) &&
             (identical(other.introduction, introduction) ||
                 other.introduction == introduction));
@@ -234,7 +234,7 @@ class _$_Sponsor implements _Sponsor {
 
   @override
   int get hashCode => Object.hash(runtimeType, name, displayName, url,
-      logoAssetName, rank, session, introduction);
+      logoAssetName, plan, session, introduction);
 
   @JsonKey(ignore: true)
   @override
@@ -249,7 +249,7 @@ abstract class _Sponsor implements Sponsor {
       required final String displayName,
       required final String url,
       required final String logoAssetName,
-      required final SponsorRank rank,
+      required final SponsorPlan plan,
       required final SponsorSession? session,
       final String introduction}) = _$_Sponsor;
 
@@ -262,7 +262,7 @@ abstract class _Sponsor implements Sponsor {
   @override
   String get logoAssetName;
   @override
-  SponsorRank get rank;
+  SponsorPlan get plan;
   @override
   SponsorSession? get session;
   @override

--- a/lib/features/sponsor/data/sponsor.freezed.dart
+++ b/lib/features/sponsor/data/sponsor.freezed.dart
@@ -1,0 +1,223 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sponsor.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$Sponsor {
+  String get name => throw _privateConstructorUsedError;
+  String get displayName => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+  List<SponsorSession> get sessions => throw _privateConstructorUsedError;
+  String get introduction => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SponsorCopyWith<Sponsor> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SponsorCopyWith<$Res> {
+  factory $SponsorCopyWith(Sponsor value, $Res Function(Sponsor) then) =
+      _$SponsorCopyWithImpl<$Res, Sponsor>;
+  @useResult
+  $Res call(
+      {String name,
+      String displayName,
+      String url,
+      List<SponsorSession> sessions,
+      String introduction});
+}
+
+/// @nodoc
+class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
+    implements $SponsorCopyWith<$Res> {
+  _$SponsorCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? displayName = null,
+    Object? url = null,
+    Object? sessions = null,
+    Object? introduction = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      displayName: null == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      sessions: null == sessions
+          ? _value.sessions
+          : sessions // ignore: cast_nullable_to_non_nullable
+              as List<SponsorSession>,
+      introduction: null == introduction
+          ? _value.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_SponsorCopyWith<$Res> implements $SponsorCopyWith<$Res> {
+  factory _$$_SponsorCopyWith(
+          _$_Sponsor value, $Res Function(_$_Sponsor) then) =
+      __$$_SponsorCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      String displayName,
+      String url,
+      List<SponsorSession> sessions,
+      String introduction});
+}
+
+/// @nodoc
+class __$$_SponsorCopyWithImpl<$Res>
+    extends _$SponsorCopyWithImpl<$Res, _$_Sponsor>
+    implements _$$_SponsorCopyWith<$Res> {
+  __$$_SponsorCopyWithImpl(_$_Sponsor _value, $Res Function(_$_Sponsor) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? displayName = null,
+    Object? url = null,
+    Object? sessions = null,
+    Object? introduction = null,
+  }) {
+    return _then(_$_Sponsor(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      displayName: null == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      sessions: null == sessions
+          ? _value._sessions
+          : sessions // ignore: cast_nullable_to_non_nullable
+              as List<SponsorSession>,
+      introduction: null == introduction
+          ? _value.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Sponsor implements _Sponsor {
+  const _$_Sponsor(
+      {required this.name,
+      required this.displayName,
+      required this.url,
+      required final List<SponsorSession> sessions,
+      this.introduction = ''})
+      : _sessions = sessions;
+
+  @override
+  final String name;
+  @override
+  final String displayName;
+  @override
+  final String url;
+  final List<SponsorSession> _sessions;
+  @override
+  List<SponsorSession> get sessions {
+    if (_sessions is EqualUnmodifiableListView) return _sessions;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sessions);
+  }
+
+  @override
+  @JsonKey()
+  final String introduction;
+
+  @override
+  String toString() {
+    return 'Sponsor(name: $name, displayName: $displayName, url: $url, sessions: $sessions, introduction: $introduction)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Sponsor &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            (identical(other.url, url) || other.url == url) &&
+            const DeepCollectionEquality().equals(other._sessions, _sessions) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, displayName, url,
+      const DeepCollectionEquality().hash(_sessions), introduction);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SponsorCopyWith<_$_Sponsor> get copyWith =>
+      __$$_SponsorCopyWithImpl<_$_Sponsor>(this, _$identity);
+}
+
+abstract class _Sponsor implements Sponsor {
+  const factory _Sponsor(
+      {required final String name,
+      required final String displayName,
+      required final String url,
+      required final List<SponsorSession> sessions,
+      final String introduction}) = _$_Sponsor;
+
+  @override
+  String get name;
+  @override
+  String get displayName;
+  @override
+  String get url;
+  @override
+  List<SponsorSession> get sessions;
+  @override
+  String get introduction;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SponsorCopyWith<_$_Sponsor> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/sponsor/data/sponsor.freezed.dart
+++ b/lib/features/sponsor/data/sponsor.freezed.dart
@@ -19,6 +19,7 @@ mixin _$Sponsor {
   String get name => throw _privateConstructorUsedError;
   String get displayName => throw _privateConstructorUsedError;
   String get url => throw _privateConstructorUsedError;
+  SponsorRank get rank => throw _privateConstructorUsedError;
   SponsorSession? get session => throw _privateConstructorUsedError;
   String get introduction => throw _privateConstructorUsedError;
 
@@ -35,6 +36,7 @@ abstract class $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
+      SponsorRank rank,
       SponsorSession? session,
       String introduction});
 
@@ -57,6 +59,7 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
+    Object? rank = null,
     Object? session = freezed,
     Object? introduction = null,
   }) {
@@ -73,6 +76,10 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
               as String,
+      rank: null == rank
+          ? _value.rank
+          : rank // ignore: cast_nullable_to_non_nullable
+              as SponsorRank,
       session: freezed == session
           ? _value.session
           : session // ignore: cast_nullable_to_non_nullable
@@ -108,6 +115,7 @@ abstract class _$$_SponsorCopyWith<$Res> implements $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
+      SponsorRank rank,
       SponsorSession? session,
       String introduction});
 
@@ -128,6 +136,7 @@ class __$$_SponsorCopyWithImpl<$Res>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
+    Object? rank = null,
     Object? session = freezed,
     Object? introduction = null,
   }) {
@@ -144,6 +153,10 @@ class __$$_SponsorCopyWithImpl<$Res>
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
               as String,
+      rank: null == rank
+          ? _value.rank
+          : rank // ignore: cast_nullable_to_non_nullable
+              as SponsorRank,
       session: freezed == session
           ? _value.session
           : session // ignore: cast_nullable_to_non_nullable
@@ -163,6 +176,7 @@ class _$_Sponsor implements _Sponsor {
       {required this.name,
       required this.displayName,
       required this.url,
+      required this.rank,
       required this.session,
       this.introduction = ''});
 
@@ -173,6 +187,8 @@ class _$_Sponsor implements _Sponsor {
   @override
   final String url;
   @override
+  final SponsorRank rank;
+  @override
   final SponsorSession? session;
   @override
   @JsonKey()
@@ -180,7 +196,7 @@ class _$_Sponsor implements _Sponsor {
 
   @override
   String toString() {
-    return 'Sponsor(name: $name, displayName: $displayName, url: $url, session: $session, introduction: $introduction)';
+    return 'Sponsor(name: $name, displayName: $displayName, url: $url, rank: $rank, session: $session, introduction: $introduction)';
   }
 
   @override
@@ -192,14 +208,15 @@ class _$_Sponsor implements _Sponsor {
             (identical(other.displayName, displayName) ||
                 other.displayName == displayName) &&
             (identical(other.url, url) || other.url == url) &&
+            (identical(other.rank, rank) || other.rank == rank) &&
             (identical(other.session, session) || other.session == session) &&
             (identical(other.introduction, introduction) ||
                 other.introduction == introduction));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, name, displayName, url, session, introduction);
+  int get hashCode => Object.hash(
+      runtimeType, name, displayName, url, rank, session, introduction);
 
   @JsonKey(ignore: true)
   @override
@@ -213,6 +230,7 @@ abstract class _Sponsor implements Sponsor {
       {required final String name,
       required final String displayName,
       required final String url,
+      required final SponsorRank rank,
       required final SponsorSession? session,
       final String introduction}) = _$_Sponsor;
 
@@ -222,6 +240,8 @@ abstract class _Sponsor implements Sponsor {
   String get displayName;
   @override
   String get url;
+  @override
+  SponsorRank get rank;
   @override
   SponsorSession? get session;
   @override

--- a/lib/features/sponsor/data/sponsor.freezed.dart
+++ b/lib/features/sponsor/data/sponsor.freezed.dart
@@ -19,6 +19,7 @@ mixin _$Sponsor {
   String get name => throw _privateConstructorUsedError;
   String get displayName => throw _privateConstructorUsedError;
   String get url => throw _privateConstructorUsedError;
+  String get logoAssetName => throw _privateConstructorUsedError;
   SponsorRank get rank => throw _privateConstructorUsedError;
   SponsorSession? get session => throw _privateConstructorUsedError;
   String get introduction => throw _privateConstructorUsedError;
@@ -36,6 +37,7 @@ abstract class $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
+      String logoAssetName,
       SponsorRank rank,
       SponsorSession? session,
       String introduction});
@@ -59,6 +61,7 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
+    Object? logoAssetName = null,
     Object? rank = null,
     Object? session = freezed,
     Object? introduction = null,
@@ -75,6 +78,10 @@ class _$SponsorCopyWithImpl<$Res, $Val extends Sponsor>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      logoAssetName: null == logoAssetName
+          ? _value.logoAssetName
+          : logoAssetName // ignore: cast_nullable_to_non_nullable
               as String,
       rank: null == rank
           ? _value.rank
@@ -115,6 +122,7 @@ abstract class _$$_SponsorCopyWith<$Res> implements $SponsorCopyWith<$Res> {
       {String name,
       String displayName,
       String url,
+      String logoAssetName,
       SponsorRank rank,
       SponsorSession? session,
       String introduction});
@@ -136,6 +144,7 @@ class __$$_SponsorCopyWithImpl<$Res>
     Object? name = null,
     Object? displayName = null,
     Object? url = null,
+    Object? logoAssetName = null,
     Object? rank = null,
     Object? session = freezed,
     Object? introduction = null,
@@ -152,6 +161,10 @@ class __$$_SponsorCopyWithImpl<$Res>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      logoAssetName: null == logoAssetName
+          ? _value.logoAssetName
+          : logoAssetName // ignore: cast_nullable_to_non_nullable
               as String,
       rank: null == rank
           ? _value.rank
@@ -176,6 +189,7 @@ class _$_Sponsor implements _Sponsor {
       {required this.name,
       required this.displayName,
       required this.url,
+      required this.logoAssetName,
       required this.rank,
       required this.session,
       this.introduction = ''});
@@ -187,6 +201,8 @@ class _$_Sponsor implements _Sponsor {
   @override
   final String url;
   @override
+  final String logoAssetName;
+  @override
   final SponsorRank rank;
   @override
   final SponsorSession? session;
@@ -196,7 +212,7 @@ class _$_Sponsor implements _Sponsor {
 
   @override
   String toString() {
-    return 'Sponsor(name: $name, displayName: $displayName, url: $url, rank: $rank, session: $session, introduction: $introduction)';
+    return 'Sponsor(name: $name, displayName: $displayName, url: $url, logoAssetName: $logoAssetName, rank: $rank, session: $session, introduction: $introduction)';
   }
 
   @override
@@ -208,6 +224,8 @@ class _$_Sponsor implements _Sponsor {
             (identical(other.displayName, displayName) ||
                 other.displayName == displayName) &&
             (identical(other.url, url) || other.url == url) &&
+            (identical(other.logoAssetName, logoAssetName) ||
+                other.logoAssetName == logoAssetName) &&
             (identical(other.rank, rank) || other.rank == rank) &&
             (identical(other.session, session) || other.session == session) &&
             (identical(other.introduction, introduction) ||
@@ -215,8 +233,8 @@ class _$_Sponsor implements _Sponsor {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, name, displayName, url, rank, session, introduction);
+  int get hashCode => Object.hash(runtimeType, name, displayName, url,
+      logoAssetName, rank, session, introduction);
 
   @JsonKey(ignore: true)
   @override
@@ -230,6 +248,7 @@ abstract class _Sponsor implements Sponsor {
       {required final String name,
       required final String displayName,
       required final String url,
+      required final String logoAssetName,
       required final SponsorRank rank,
       required final SponsorSession? session,
       final String introduction}) = _$_Sponsor;
@@ -240,6 +259,8 @@ abstract class _Sponsor implements Sponsor {
   String get displayName;
   @override
   String get url;
+  @override
+  String get logoAssetName;
   @override
   SponsorRank get rank;
   @override

--- a/lib/features/sponsor/data/sponsor_rank.dart
+++ b/lib/features/sponsor/data/sponsor_rank.dart
@@ -1,4 +1,4 @@
-enum SponsorRank {
+enum SponsorPlan {
   platinum,
   gold,
   silver;

--- a/lib/features/sponsor/data/sponsor_rank.dart
+++ b/lib/features/sponsor/data/sponsor_rank.dart
@@ -1,0 +1,5 @@
+enum SponsorRank {
+  platinum,
+  gold,
+  silver;
+}

--- a/lib/features/sponsor/data/sponsor_session.dart
+++ b/lib/features/sponsor/data/sponsor_session.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: invalid_annotation_target
-
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'sponsor_session.freezed.dart';

--- a/lib/features/sponsor/data/sponsor_session.dart
+++ b/lib/features/sponsor/data/sponsor_session.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sponsor_session.freezed.dart';
+
+@freezed
+class SponsorSession with _$SponsorSession {
+  const factory SponsorSession({
+    required String title,
+    required String url,
+    required String scheduledAt,
+  }) = _SponsorSession;
+}

--- a/lib/features/sponsor/data/sponsor_session.dart
+++ b/lib/features/sponsor/data/sponsor_session.dart
@@ -5,6 +5,7 @@ part 'sponsor_session.freezed.dart';
 @freezed
 class SponsorSession with _$SponsorSession {
   const factory SponsorSession({
+    required String id,
     required String title,
     required String url,
     required String scheduledAt,

--- a/lib/features/sponsor/data/sponsor_session.freezed.dart
+++ b/lib/features/sponsor/data/sponsor_session.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$SponsorSession {
+  String get id => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   String get url => throw _privateConstructorUsedError;
   String get scheduledAt => throw _privateConstructorUsedError;
@@ -31,7 +32,7 @@ abstract class $SponsorSessionCopyWith<$Res> {
           SponsorSession value, $Res Function(SponsorSession) then) =
       _$SponsorSessionCopyWithImpl<$Res, SponsorSession>;
   @useResult
-  $Res call({String title, String url, String scheduledAt});
+  $Res call({String id, String title, String url, String scheduledAt});
 }
 
 /// @nodoc
@@ -47,11 +48,16 @@ class _$SponsorSessionCopyWithImpl<$Res, $Val extends SponsorSession>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? id = null,
     Object? title = null,
     Object? url = null,
     Object? scheduledAt = null,
   }) {
     return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
       title: null == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -76,7 +82,7 @@ abstract class _$$_SponsorSessionCopyWith<$Res>
       __$$_SponsorSessionCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String title, String url, String scheduledAt});
+  $Res call({String id, String title, String url, String scheduledAt});
 }
 
 /// @nodoc
@@ -90,11 +96,16 @@ class __$$_SponsorSessionCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? id = null,
     Object? title = null,
     Object? url = null,
     Object? scheduledAt = null,
   }) {
     return _then(_$_SponsorSession(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
       title: null == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -115,8 +126,13 @@ class __$$_SponsorSessionCopyWithImpl<$Res>
 
 class _$_SponsorSession implements _SponsorSession {
   const _$_SponsorSession(
-      {required this.title, required this.url, required this.scheduledAt});
+      {required this.id,
+      required this.title,
+      required this.url,
+      required this.scheduledAt});
 
+  @override
+  final String id;
   @override
   final String title;
   @override
@@ -126,7 +142,7 @@ class _$_SponsorSession implements _SponsorSession {
 
   @override
   String toString() {
-    return 'SponsorSession(title: $title, url: $url, scheduledAt: $scheduledAt)';
+    return 'SponsorSession(id: $id, title: $title, url: $url, scheduledAt: $scheduledAt)';
   }
 
   @override
@@ -134,6 +150,7 @@ class _$_SponsorSession implements _SponsorSession {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_SponsorSession &&
+            (identical(other.id, id) || other.id == id) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.scheduledAt, scheduledAt) ||
@@ -141,7 +158,7 @@ class _$_SponsorSession implements _SponsorSession {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, title, url, scheduledAt);
+  int get hashCode => Object.hash(runtimeType, id, title, url, scheduledAt);
 
   @JsonKey(ignore: true)
   @override
@@ -152,10 +169,13 @@ class _$_SponsorSession implements _SponsorSession {
 
 abstract class _SponsorSession implements SponsorSession {
   const factory _SponsorSession(
-      {required final String title,
+      {required final String id,
+      required final String title,
       required final String url,
       required final String scheduledAt}) = _$_SponsorSession;
 
+  @override
+  String get id;
   @override
   String get title;
   @override

--- a/lib/features/sponsor/data/sponsor_session.freezed.dart
+++ b/lib/features/sponsor/data/sponsor_session.freezed.dart
@@ -1,0 +1,169 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sponsor_session.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$SponsorSession {
+  String get title => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+  String get scheduledAt => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SponsorSessionCopyWith<SponsorSession> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SponsorSessionCopyWith<$Res> {
+  factory $SponsorSessionCopyWith(
+          SponsorSession value, $Res Function(SponsorSession) then) =
+      _$SponsorSessionCopyWithImpl<$Res, SponsorSession>;
+  @useResult
+  $Res call({String title, String url, String scheduledAt});
+}
+
+/// @nodoc
+class _$SponsorSessionCopyWithImpl<$Res, $Val extends SponsorSession>
+    implements $SponsorSessionCopyWith<$Res> {
+  _$SponsorSessionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? url = null,
+    Object? scheduledAt = null,
+  }) {
+    return _then(_value.copyWith(
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      scheduledAt: null == scheduledAt
+          ? _value.scheduledAt
+          : scheduledAt // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_SponsorSessionCopyWith<$Res>
+    implements $SponsorSessionCopyWith<$Res> {
+  factory _$$_SponsorSessionCopyWith(
+          _$_SponsorSession value, $Res Function(_$_SponsorSession) then) =
+      __$$_SponsorSessionCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String title, String url, String scheduledAt});
+}
+
+/// @nodoc
+class __$$_SponsorSessionCopyWithImpl<$Res>
+    extends _$SponsorSessionCopyWithImpl<$Res, _$_SponsorSession>
+    implements _$$_SponsorSessionCopyWith<$Res> {
+  __$$_SponsorSessionCopyWithImpl(
+      _$_SponsorSession _value, $Res Function(_$_SponsorSession) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? url = null,
+    Object? scheduledAt = null,
+  }) {
+    return _then(_$_SponsorSession(
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      scheduledAt: null == scheduledAt
+          ? _value.scheduledAt
+          : scheduledAt // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_SponsorSession implements _SponsorSession {
+  const _$_SponsorSession(
+      {required this.title, required this.url, required this.scheduledAt});
+
+  @override
+  final String title;
+  @override
+  final String url;
+  @override
+  final String scheduledAt;
+
+  @override
+  String toString() {
+    return 'SponsorSession(title: $title, url: $url, scheduledAt: $scheduledAt)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_SponsorSession &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.scheduledAt, scheduledAt) ||
+                other.scheduledAt == scheduledAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, title, url, scheduledAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SponsorSessionCopyWith<_$_SponsorSession> get copyWith =>
+      __$$_SponsorSessionCopyWithImpl<_$_SponsorSession>(this, _$identity);
+}
+
+abstract class _SponsorSession implements SponsorSession {
+  const factory _SponsorSession(
+      {required final String title,
+      required final String url,
+      required final String scheduledAt}) = _$_SponsorSession;
+
+  @override
+  String get title;
+  @override
+  String get url;
+  @override
+  String get scheduledAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SponsorSessionCopyWith<_$_SponsorSession> get copyWith =>
+      throw _privateConstructorUsedError;
+}


### PR DESCRIPTION
## Issue

- [スポンサーセクション（第2段階）の設計・実装 · Issue #164 · FlutterKaigi/TasksBoard](https://github.com/FlutterKaigi/TasksBoard/issues/164)

## Overview (Required)

- スポンサー関連のモデルを追加します
  - セッションに関するクラスは #143 で作成されたものと後々統合していく可能性がありますが、現状は別途作成としています

## Links

- 

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
