### PR TITLE
`build.yaml`に`duplicate_ignore`の除外を追加

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,3 +5,4 @@ targets:
         options:
           ignore_for_file:
             - type=lint
+            - duplicate_ignore


### PR DESCRIPTION
## Overview (Required)

- duplicate_ignoreを追加
  - riverpod_generator生成クラスが`// ignore_for_file: type=lint`を作成する関係で 重複したignoreが生成されてしまいます
  - freezedとの兼ね合いもあり`type=lint`は無効にしたくない

## Links

- ref: https://github.com/yumemi-inc/flutter-yumemi-lints/pull/25
