### PR TITLE
HeaderBarを固定

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/theme.dart';
@@ -45,17 +46,17 @@ class MainPage extends HookWidget {
         ),
       ),
       HeaderItemButtonData(
-        title: 'Event',
+        title: 'Ticket',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.event.currentContext!,
+          sectionKeys.ticket.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),
       ),
       HeaderItemButtonData(
-        title: 'Ticket',
+        title: 'Event',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.ticket.currentContext!,
+          sectionKeys.event.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),
@@ -131,19 +132,8 @@ class _MainPageBody extends StatelessWidget {
         CustomScrollView(
           controller: scrollController,
           slivers: [
-            _Sliver(
-              padding: padding,
-              child: HeaderBar(
-                items: items,
-                onTitleTap: () async => scrollController.animateTo(
-                  0,
-                  duration: const Duration(milliseconds: 750),
-                  curve: Curves.easeOutCirc,
-                ),
-              ),
-            ),
             const SliverToBoxAdapter(
-              child: Spaces.vertical_30,
+              child: Spaces.vertical_40,
             ),
             _Sliver(
               padding: padding,
@@ -224,6 +214,27 @@ class _MainPageBody extends StatelessWidget {
               child: Footer(),
             ),
           ],
+        ),
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          child: ClipRRect(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: 16,
+                sigmaY: 16,
+              ),
+              child: HeaderBar(
+                items: items,
+                onTitleTap: () async => scrollController.animateTo(
+                  0,
+                  duration: const Duration(milliseconds: 750),
+                  curve: Curves.easeOutCirc,
+                ),
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -77,6 +77,15 @@ class MainPage extends HookWidget {
         sectionKeys: sectionKeys,
         items: items,
       ),
+      appBar: HeaderBar(
+        items: items,
+        onTitleTap: () async => scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 750),
+          curve: Curves.easeOutCirc,
+        ),
+      ),
+      extendBodyBehindAppBar: true,
     );
   }
 }
@@ -131,19 +140,8 @@ class _MainPageBody extends StatelessWidget {
         CustomScrollView(
           controller: scrollController,
           slivers: [
-            _Sliver(
-              padding: padding,
-              child: HeaderBar(
-                items: items,
-                onTitleTap: () async => scrollController.animateTo(
-                  0,
-                  duration: const Duration(milliseconds: 750),
-                  curve: Curves.easeOutCirc,
-                ),
-              ),
-            ),
             const SliverToBoxAdapter(
-              child: Spaces.vertical_30,
+              child: Spaces.vertical_40,
             ),
             _Sliver(
               padding: padding,

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -45,17 +45,17 @@ class MainPage extends HookWidget {
         ),
       ),
       HeaderItemButtonData(
-        title: 'Event',
+        title: 'Ticket',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.event.currentContext!,
+          sectionKeys.ticket.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),
       ),
       HeaderItemButtonData(
-        title: 'Ticket',
+        title: 'Event',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.ticket.currentContext!,
+          sectionKeys.event.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -34,39 +34,38 @@ class MainPage extends HookWidget {
       sponsor: GlobalObjectKey('sponsorSectionKey'),
       staff: GlobalObjectKey('staffSectionKey'),
     );
+    const headerBarKey = GlobalObjectKey('headerBarKey');
+
+    Future<void> scrollToSection(GlobalKey key) async {
+      final height = MediaQuery.sizeOf(context).height;
+      // headerbar の高さ
+      final headerBarHeight = headerBarKey.currentContext!.size!.height;
+      // 画面全体に対する HeaderBarの高さの割合
+      final ratioOfHeaderBar = headerBarHeight / height;
+      return Scrollable.ensureVisible(
+        key.currentContext!,
+        alignment: ratioOfHeaderBar,
+        curve: Curves.easeOutCirc,
+        duration: const Duration(milliseconds: 750),
+      );
+    }
 
     final items = <HeaderItemButtonData>[
       HeaderItemButtonData(
         title: 'Access',
-        onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.access.currentContext!,
-          curve: Curves.easeOutCirc,
-          duration: const Duration(milliseconds: 750),
-        ),
+        onPressed: () async => scrollToSection(sectionKeys.access),
       ),
       HeaderItemButtonData(
         title: 'Ticket',
-        onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.ticket.currentContext!,
-          curve: Curves.easeOutCirc,
-          duration: const Duration(milliseconds: 750),
-        ),
+        onPressed: () async => scrollToSection(sectionKeys.ticket),
       ),
       HeaderItemButtonData(
         title: 'Event',
-        onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.event.currentContext!,
-          curve: Curves.easeOutCirc,
-          duration: const Duration(milliseconds: 750),
-        ),
+        onPressed: () async => scrollToSection(sectionKeys.event),
       ),
       HeaderItemButtonData(
         title: 'Staff',
-        onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.staff.currentContext!,
-          curve: Curves.easeOutCirc,
-          duration: const Duration(milliseconds: 750),
-        ),
+        onPressed: () async => scrollToSection(sectionKeys.staff),
       ),
     ];
 
@@ -84,6 +83,7 @@ class MainPage extends HookWidget {
           duration: const Duration(milliseconds: 750),
           curve: Curves.easeOutCirc,
         ),
+        key: headerBarKey,
       ),
       extendBodyBehindAppBar: true,
     );

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/theme.dart';
@@ -46,17 +45,17 @@ class MainPage extends HookWidget {
         ),
       ),
       HeaderItemButtonData(
-        title: 'Ticket',
+        title: 'Event',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.ticket.currentContext!,
+          sectionKeys.event.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),
       ),
       HeaderItemButtonData(
-        title: 'Event',
+        title: 'Ticket',
         onPressed: () async => Scrollable.ensureVisible(
-          sectionKeys.event.currentContext!,
+          sectionKeys.ticket.currentContext!,
           curve: Curves.easeOutCirc,
           duration: const Duration(milliseconds: 750),
         ),
@@ -132,8 +131,19 @@ class _MainPageBody extends StatelessWidget {
         CustomScrollView(
           controller: scrollController,
           slivers: [
+            _Sliver(
+              padding: padding,
+              child: HeaderBar(
+                items: items,
+                onTitleTap: () async => scrollController.animateTo(
+                  0,
+                  duration: const Duration(milliseconds: 750),
+                  curve: Curves.easeOutCirc,
+                ),
+              ),
+            ),
             const SliverToBoxAdapter(
-              child: Spaces.vertical_40,
+              child: Spaces.vertical_30,
             ),
             _Sliver(
               padding: padding,
@@ -214,27 +224,6 @@ class _MainPageBody extends StatelessWidget {
               child: Footer(),
             ),
           ],
-        ),
-        Positioned(
-          top: 0,
-          left: 0,
-          right: 0,
-          child: ClipRRect(
-            child: BackdropFilter(
-              filter: ImageFilter.blur(
-                sigmaX: 16,
-                sigmaY: 16,
-              ),
-              child: HeaderBar(
-                items: items,
-                onTitleTap: () async => scrollController.animateTo(
-                  0,
-                  duration: const Duration(milliseconds: 750),
-                  curve: Curves.easeOutCirc,
-                ),
-              ),
-            ),
-          ),
         ),
       ],
     );

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -37,14 +37,13 @@ class MainPage extends HookWidget {
     const headerBarKey = GlobalObjectKey('headerBarKey');
 
     Future<void> scrollToSection(GlobalKey key) async {
-      final height = MediaQuery.sizeOf(context).height;
-      // headerbar の高さ
-      final headerBarHeight = headerBarKey.currentContext!.size!.height;
-      // 画面全体に対する HeaderBarの高さの割合
-      final ratioOfHeaderBar = headerBarHeight / height;
+      final displayHeight = MediaQuery.sizeOf(context).height;
+      final targetWidgetHeight = key.currentContext!.size!.height;
+      final alignment = kToolbarHeight / (displayHeight - targetWidgetHeight);
+
       return Scrollable.ensureVisible(
         key.currentContext!,
-        alignment: ratioOfHeaderBar,
+        alignment: alignment,
         curve: Curves.easeOutCirc,
         duration: const Duration(milliseconds: 750),
       );

--- a/lib/features/header/ui/header_widget.dart
+++ b/lib/features/header/ui/header_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:animations/animations.dart';
 import 'package:confwebsite2023/core/components/flutter_kaigi_logo.dart';
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
@@ -96,11 +98,19 @@ class HeaderBar extends HookWidget implements PreferredSizeWidget {
         ],
       ),
     );
-    return Padding(
-      padding: const EdgeInsets.only(top: 10, left: 10, right: 10),
-      child: ResponsiveWidget(
-        largeWidget: desktopBar,
-        smallWidget: mobileBar,
+    return ClipRRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(
+          sigmaX: 16,
+          sigmaY: 16,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: ResponsiveWidget(
+            largeWidget: desktopBar,
+            smallWidget: mobileBar,
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/header/ui/header_widget.dart
+++ b/lib/features/header/ui/header_widget.dart
@@ -27,10 +27,7 @@ class HeaderBar extends HookWidget implements PreferredSizeWidget {
         // SiteName
         TextButton(
           onPressed: onTitleTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: logo,
-          ),
+          child: logo,
         );
 
     final mobileBar = Row(
@@ -76,9 +73,9 @@ class HeaderBar extends HookWidget implements PreferredSizeWidget {
               iconColor: baselineColorScheme.ref.secondary.secondary80,
               textStyle: GoogleFonts.poppins(
                 color: baselineColorScheme.ref.secondary.secondary80,
-                fontSize: 18,
+                fontSize: 24,
                 fontWeight: FontWeight.w600,
-                height: 1.5,
+                height: 1.2,
               ),
             ),
           ),


### PR DESCRIPTION
## Overview (Required)

- HeaderBarを画面上部に固定しました
  - 関連して余白を調整しました
 

![image](https://github.com/FlutterKaigi/2023/assets/73390859/53f249b5-ea65-4130-abaa-3c8d7a65b274)
