### PR TITLE
見出しテキスト欠損の修正とスクロールのパフォーマンス改善

### DIFF
--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -30,22 +30,19 @@ final class SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final component = ShaderMask(
-      shaderCallback: (Rect bounds) {
-        // NOTE: bounds から取得するとグラデーションが想定どおりかからないため、テキストサイズを別途取得する
-        final textSize = _getTextSize(maxWidth: bounds.width);
-        return gradient.createShader(
-          Rect.fromLTWH(0, 0, textSize.width, textSize.height),
-        );
-      },
-      blendMode: BlendMode.srcIn,
-      child: Padding(
-        // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
-        padding: const EdgeInsets.all(_blurRadius),
-        child: Text(
-          text,
-          style: style.copyWith(
-            color: Colors.white,
+    final component = Align(
+      alignment: Alignment.centerLeft,
+      child: ShaderMask(
+        shaderCallback: gradient.createShader,
+        blendMode: BlendMode.srcIn,
+        child: Padding(
+          // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
+          padding: const EdgeInsets.all(_blurRadius),
+          child: Text(
+            text,
+            style: style.copyWith(
+              color: Colors.white,
+            ),
           ),
         ),
       ),
@@ -60,21 +57,5 @@ final class SectionHeader extends StatelessWidget {
     }
 
     return component;
-  }
-
-  /// 描画するテキストのサイズを取得する
-  Size _getTextSize({
-    required double maxWidth,
-  }) {
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: style,
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout(
-        maxWidth: maxWidth,
-      );
-    return textPainter.size;
   }
 }

--- a/lib/core/components/section_header.dart
+++ b/lib/core/components/section_header.dart
@@ -32,16 +32,18 @@ final class SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final component = Align(
       alignment: Alignment.centerLeft,
-      child: ShaderMask(
-        shaderCallback: gradient.createShader,
-        blendMode: BlendMode.srcIn,
-        child: Padding(
-          // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
-          padding: const EdgeInsets.all(_blurRadius),
-          child: Text(
-            text,
-            style: style.copyWith(
-              color: Colors.white,
+      child: RepaintBoundary(
+        child: ShaderMask(
+          shaderCallback: gradient.createShader,
+          blendMode: BlendMode.srcIn,
+          child: Padding(
+            // NOTE: Text Widget の描画範囲から外れて文字やブラーが見切れてしまうため、現状は左右に余白を設けている
+            padding: const EdgeInsets.all(_blurRadius),
+            child: Text(
+              text,
+              style: style.copyWith(
+                color: Colors.white,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Issue

- #173

## Overview (Required)

自分でソースコードから実行すると、見出しのテキストが切れる現象は再現できませんでした。
しかし、原因になっていそうな部分があったことと、macOS と iOS で明らかにパフォーマンスの問題があったことから、できる範囲の改善だけでもしたほうがいいと考えました。

解決できているか判断できないため issue の自動 close の設定はしていません。
直っているようでしたら閉じていただければと思います。

## Screenshot

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td rowspan="2"><img src="https://github.com/FlutterKaigi/2023/assets/20254485/eebcb5fa-a228-4b78-8d95-b9c727487714" width="320"></td>
<td><img src="https://github.com/FlutterKaigi/2023/assets/20254485/3bbcbfa9-3b07-47f4-898c-0a5ad576df71" width="320"></td>
</tr>
<tr>
<td><img src="https://github.com/FlutterKaigi/2023/assets/20254485/15a92438-78ed-4909-abb4-f78562c2d383" width="320"></td>
</tr>
</table>

## Details

### グラデーションの範囲を決めるための煩雑な処理をシンプル化

https://github.com/FlutterKaigi/2023/blob/4c8936e66656b1f957fabded19e140d58fe6a598/lib/core/components/section_header.dart#L34-L40

もともとこうなっていて「グラデーションが想定どおりかからない」の具体的な内容がわかりませんでした。

<img src="https://github.com/FlutterKaigi/2023/assets/20254485/bce5d52c-493f-4d56-9a32-a58785fcb5b3">

このようにグラデーションが緩やかすぎて全体がほとんどピンクに見える現象だと考えましたが、合っているでしょうか。
これは Staff の部分でしか起こっていませんでした。
画面幅いっぱいにテキストの領域が広がっていることが原因でグラデーションの範囲も広くなっていたのだと思われます。

直すには実際のテキストの幅だけになるようにすればいいので、そのように改善しました。
それが一つ目のコミットです。https://github.com/FlutterKaigi/2023/commit/55e5a19af5927c49b497f0983fabae88b0c8c07b

### パフォーマンスの問題

上記の煩雑な処理が見出しが切れる原因だと想像していたので、その修正だけで解決できるかもしれないと考えていたのですが、iPad で改善が見られず、スクロールの動きも非常に悪いままでした。
そこで様々に試しながら妥協点を探りました。

#### 試したこと 1： ShaderMask を外してみる

Padding と Text のみにしてみると通常のスムーズな動きになりました。
Transform.translate を使っていることは無関係のようでした。
ShaderMask が原因であることは間違いないと思います。

#### 試したこと 2： ShaderMask の部分も含めてキャッシュ

StatefulWidget に変え、`didChangeDependencies()` で ShaderMask 以下を用意しておくことを試しました。
しかし、その時点ではなく実際に描画するときが原因になっているようで全く改善しませんでした。
`initState()` に移しても同様でした。

#### 試したこと 3： TextStyle の `foreground` を使う

ShaderMask の代わりに TextStyle で `foreground: Paint()..shader = gradient.createShader(適当なRect)` を指定する方法を試すとスムーズになりましたが、iPad で見るとグラデーションが全く表示されませんでした。
Flutter 自体の問題だと思われます。

#### 最終的な方法

RepaintBoundary で包みました。
パフォーマンスはこれでかなり改善しています。

ただ、iPad 実機では [issue のページに貼ったスクショ](https://github.com/FlutterKaigi/2023/issues/173#issuecomment-1732280563)のように一部が欠ける現象は直っていません。
これも Flutter の問題のように思えますが、調べても古い情報ばかりで最近の情報は見つかりませんでした。

Mac の Safari と iPhone シミュレータでは欠けることがなく、動きも割とスムーズになっていることを確認しました。
