### PR TITLE
ツイートボタンとコピーボタンのアクションを実装

### DIFF
--- a/lib/core/components/copy_url_button.dart
+++ b/lib/core/components/copy_url_button.dart
@@ -1,18 +1,31 @@
 import 'package:confwebsite2023/core/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 final class CopyUrlButton extends StatelessWidget {
   const CopyUrlButton({
-    required this.onPressed,
+    required this.shareUrl,
     super.key,
   });
 
-  final VoidCallback? onPressed;
+  final String shareUrl;
 
   @override
   Widget build(BuildContext context) => FilledButton.icon(
-        onPressed: onPressed,
+        onPressed: () async {
+          final data = ClipboardData(text: shareUrl);
+          await Clipboard.setData(data);
+
+          if (!context.mounted) {
+            return;
+          }
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('URLをコピーしました'),
+            ),
+          );
+        },
         icon: SvgPicture.asset(
           Assets.icons.copy,
           width: 18,

--- a/lib/core/components/social_share.dart
+++ b/lib/core/components/social_share.dart
@@ -4,15 +4,13 @@ import 'package:flutter/material.dart';
 
 final class SocialShare extends StatelessWidget {
   const SocialShare({
-    required this.onTweetPressed,
-    required this.onCopyUrlPressed,
+    required this.shareUrl,
     this.alignment = WrapAlignment.end,
     super.key,
   });
 
   final WrapAlignment alignment;
-  final VoidCallback? onTweetPressed;
-  final VoidCallback? onCopyUrlPressed;
+  final String shareUrl;
 
   @override
   Widget build(BuildContext context) => Wrap(
@@ -21,10 +19,10 @@ final class SocialShare extends StatelessWidget {
         runSpacing: 10,
         children: [
           TweetButton(
-            onPressed: onTweetPressed,
+            shareUrl: shareUrl,
           ),
           CopyUrlButton(
-            onPressed: onCopyUrlPressed,
+            shareUrl: shareUrl,
           ),
         ],
       );

--- a/lib/core/components/tweet_button.dart
+++ b/lib/core/components/tweet_button.dart
@@ -14,7 +14,7 @@ final class TweetButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Link(
         uri: Uri.parse(
-          'https://twitter.com/share?text=$shareUrl&hashtags=flutterkaigi&via=FlutterKaigi',
+          'https://twitter.com/share?url=$shareUrl&hashtags=flutterkaigi&via=FlutterKaigi',
         ),
         target: LinkTarget.blank,
         builder: (context, openLink) {

--- a/lib/core/components/tweet_button.dart
+++ b/lib/core/components/tweet_button.dart
@@ -1,27 +1,36 @@
 import 'package:confwebsite2023/core/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:url_launcher/link.dart';
 
 final class TweetButton extends StatelessWidget {
   const TweetButton({
-    required this.onPressed,
+    required this.shareUrl,
     super.key,
   });
 
-  final VoidCallback? onPressed;
+  final String shareUrl;
 
   @override
-  Widget build(BuildContext context) => FilledButton.icon(
-        onPressed: onPressed,
-        icon: SvgPicture.asset(
-          Assets.icons.twitter,
-          width: 18,
-          height: 18,
-          colorFilter: ColorFilter.mode(
-            Theme.of(context).colorScheme.onPrimary,
-            BlendMode.srcIn,
-          ),
+  Widget build(BuildContext context) => Link(
+        uri: Uri.parse(
+          'https://twitter.com/share?text=$shareUrl&hashtags=flutterkaigi&via=FlutterKaigi',
         ),
-        label: const Text('ツイートする'),
+        target: LinkTarget.blank,
+        builder: (context, openLink) {
+          return FilledButton.icon(
+            onPressed: openLink,
+            icon: SvgPicture.asset(
+              Assets.icons.twitter,
+              width: 18,
+              height: 18,
+              colorFilter: ColorFilter.mode(
+                Theme.of(context).colorScheme.onPrimary,
+                BlendMode.srcIn,
+              ),
+            ),
+            label: const Text('ツイートする'),
+          );
+        },
       );
 }

--- a/lib/features/sponsor/ui/detail/sponsor_detail.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_detail.dart
@@ -43,8 +43,6 @@ final class SponsorDetail extends ConsumerWidget {
         padding: 40,
         contentGap: 20,
         sectionGap: 40,
-        onTweetPressed: () {},
-        onCopyUrlPressed: () {},
       ),
       smallWidget: SponsorDetailContent(
         sponsor: sponsor,
@@ -55,8 +53,6 @@ final class SponsorDetail extends ConsumerWidget {
         padding: 16,
         contentGap: 16,
         sectionGap: 24,
-        onTweetPressed: () {},
-        onCopyUrlPressed: () {},
       ),
     );
   }

--- a/lib/features/sponsor/ui/detail/sponsor_detail_content.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_detail_content.dart
@@ -1,3 +1,4 @@
+import 'package:confwebsite2023/app/router/router.dart';
 import 'package:confwebsite2023/core/components/social_share.dart';
 import 'package:confwebsite2023/features/sponsor/data/sponsor.dart';
 import 'package:confwebsite2023/features/sponsor/data/sponsor_plan.dart';
@@ -35,7 +36,8 @@ final class SponsorDetailContent extends StatelessWidget {
     final contentVerticalGap = SizedBox(height: contentGap);
     final sectionVerticalGap = SizedBox(height: sectionGap);
 
-    final currentUrl = Uri.base.toString();
+    final route = SponsorPageRoute(name: sponsor.name);
+    final shareUrl = Uri.base.origin + route.location;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -44,7 +46,7 @@ final class SponsorDetailContent extends StatelessWidget {
         SizedBox(
           width: double.infinity,
           child: SocialShare(
-            shareUrl: currentUrl,
+            shareUrl: shareUrl,
           ),
         ),
         contentVerticalGap,
@@ -96,7 +98,7 @@ final class SponsorDetailContent extends StatelessWidget {
         SizedBox(
           width: double.infinity,
           child: SocialShare(
-            shareUrl: currentUrl,
+            shareUrl: shareUrl,
           ),
         ),
       ],

--- a/lib/features/sponsor/ui/detail/sponsor_detail_content.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_detail_content.dart
@@ -17,8 +17,6 @@ final class SponsorDetailContent extends StatelessWidget {
     required this.padding,
     required this.contentGap,
     required this.sectionGap,
-    required this.onTweetPressed,
-    required this.onCopyUrlPressed,
     super.key,
   });
 
@@ -31,13 +29,13 @@ final class SponsorDetailContent extends StatelessWidget {
   final double padding;
   final double contentGap;
   final double sectionGap;
-  final VoidCallback? onTweetPressed;
-  final VoidCallback? onCopyUrlPressed;
 
   @override
   Widget build(BuildContext context) {
     final contentVerticalGap = SizedBox(height: contentGap);
     final sectionVerticalGap = SizedBox(height: sectionGap);
+
+    final currentUrl = Uri.base.toString();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -46,8 +44,7 @@ final class SponsorDetailContent extends StatelessWidget {
         SizedBox(
           width: double.infinity,
           child: SocialShare(
-            onTweetPressed: onTweetPressed,
-            onCopyUrlPressed: onCopyUrlPressed,
+            shareUrl: currentUrl,
           ),
         ),
         contentVerticalGap,
@@ -99,8 +96,7 @@ final class SponsorDetailContent extends StatelessWidget {
         SizedBox(
           width: double.infinity,
           child: SocialShare(
-            onTweetPressed: onTweetPressed,
-            onCopyUrlPressed: onCopyUrlPressed,
+            shareUrl: currentUrl,
           ),
         ),
       ],


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

ツイートボタンとコピーボタンのアクションを実装しました。
どちらもスポンサー詳細画面の URL をシェアするようにしています。


## Screenshot

<video src=https://github.com/FlutterKaigi/2023/assets/32213113/bc294a12-2ee3-4ebd-b2a3-7e44e8594313 width=320 />