### PR TITLE
スポンサーセクションヘッダーの位置修正

### DIFF
--- a/lib/features/sponsor/ui/list/sponsors_section.dart
+++ b/lib/features/sponsor/ui/list/sponsors_section.dart
@@ -46,6 +46,7 @@ final class SponsorsSection extends ConsumerWidget {
     );
 
     return const Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SponsorSectionHeader('Sponsors'),
         verticalGapBelowTitles,


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

スポンサーセクションヘッダーの位置を左寄せになるよう修正しました。

## Screenshot

|           デスクトップ           |           モバイル            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/FlutterKaigi/2023/assets/32213113/7fd29d47-8b68-460a-a6c7-80e9e9582f24" width="300" /> | <img src="https://github.com/FlutterKaigi/2023/assets/32213113/023947a9-a96d-4e83-a402-868ce7954acd" width="300" /> |