### PR TITLE
RepaintBoundary でスポンサーカードを包むよう修正

### DIFF
--- a/lib/features/sponsor/ui/list/sponsor_logo_cards.dart
+++ b/lib/features/sponsor/ui/list/sponsor_logo_cards.dart
@@ -93,7 +93,7 @@ final class _StatelessSponsorLogoCards extends StatelessWidget {
       alignment: WrapAlignment.center,
       spacing: 24,
       runSpacing: 24,
-      children: sponsorCards,
+      children: RepaintBoundary.wrapAll(sponsorCards),
     );
   }
 }


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

RepaintBoundary でスポンサーカードを包むようにして、余計な再描画が実行されエラーが発生しないように修正しました。

エラーはヘッダーバーのリンクで移動することによって発生していました。

↓ エラーメッセージ

```shell
======== Exception caught by rendering library =====================================================
The following assertion was thrown during paint():
Assertion failed: org-dartlang-sdk:///lib/_engine/engine/html/path/path_ref.dart:902:12
isValid
is not true

The relevant error-causing widget was: 
  Card Card:file:///Users/t_okayama/Repos/private/FlutterKaigi/2023/lib/features/sponsor/ui/list/sponsor_logo_cards.dart:71:14
When the exception was thrown, this was the stack: 
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 294:49      throw_
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 35:3        assertFailed
lib/_engine/engine/html/path/path_ref.dart 902:12                                 debugValidate
lib/_engine/engine/html/path/path_ref.dart 84:5                                   shiftedFrom
lib/_engine/engine/html/path/path.dart 37:27                                      shiftedFrom
lib/_engine/engine/html/path/path.dart 1270:19                                    shift
packages/flutter/src/rendering/proxy_box.dart 2127:29                             paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/shifted_box.dart 74:14                             paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/proxy_box.dart 129:12                              paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/box.dart 2875:14                                   defaultPaint
packages/flutter/src/rendering/wrap.dart 750:7                                    paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/box.dart 2875:14                                   defaultPaint
packages/flutter/src/rendering/flex.dart 1040:7                                   paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/shifted_box.dart 74:14                             paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/box.dart 2875:14                                   defaultPaint
packages/flutter/src/rendering/flex.dart 1040:7                                   paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/sliver.dart 1828:14                                paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/sliver_padding.dart 263:14                         paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 250:12                                 paintChild
packages/flutter/src/rendering/viewport.dart 690:16                               [_paintContents]
packages/flutter/src/rendering/object.dart 486:12                                 pushLayer
packages/flutter/src/rendering/object.dart 546:7                                  pushClipRect
packages/flutter/src/rendering/viewport.dart 665:37                               paint
packages/flutter/src/rendering/object.dart 3210:7                                 [_paintWithContext]
packages/flutter/src/rendering/object.dart 166:10                                 _repaintCompositedChild
packages/flutter/src/rendering/object.dart 109:5                                  repaintCompositedChild
packages/flutter/src/rendering/object.dart 1158:31                                flushPaint
packages/flutter/src/rendering/object.dart 1168:14                                flushPaint
packages/flutter/src/rendering/binding.dart 593:23                                drawFrame
packages/flutter/src/widgets/binding.dart 976:13                                  drawFrame
packages/flutter/src/rendering/binding.dart 457:5                                 [_handlePersistentFrameCallback]
packages/flutter/src/scheduler/binding.dart 1301:15                               [_invokeFrameCallback]
packages/flutter/src/scheduler/binding.dart 1231:9                                handleDrawFrame
packages/flutter/src/scheduler/binding.dart 1089:5                                [_handleDrawFrame]
lib/_engine/engine/platform_dispatcher.dart 1304:13                               invoke
lib/_engine/engine/platform_dispatcher.dart 278:5                                 invokeOnDrawFrame
lib/_engine/engine/initialization.dart 186:45                                     <fn>
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 574:37  _checkAndCall
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 579:39  dcall
The following RenderObject was being processed when the exception was fired: RenderPhysicalShape#ff873 relayoutBoundary=up9
...  needs compositing
...  parentData: offset=Offset(4.0, 4.0) (can use size)
...  constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
...  size: Size(160.0, 80.0)
...  elevation: 1.0
...  color: Color(0xff0a090d)
...  shadowColor: Color(0xff0a090d)
...  clipper: ShapeBorderClipper
RenderObject: RenderPhysicalShape#ff873 relayoutBoundary=up9
  needs compositing
  parentData: offset=Offset(4.0, 4.0) (can use size)
  constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
  size: Size(160.0, 80.0)
  elevation: 1.0
  color: Color(0xff0a090d)
  shadowColor: Color(0xff0a090d)
  clipper: ShapeBorderClipper
...  child: RenderCustomPaint#4827f relayoutBoundary=up10
...    needs compositing
...    parentData: <none> (can use size)
...    constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
...    size: Size(160.0, 80.0)
...    painter: null
...    foregroundPainter: _ShapeBorderPainter#a350d()
...    child: _RenderInkFeatures#5f17e relayoutBoundary=up11
...      needs compositing
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
...      size: Size(160.0, 80.0)
...      child: RenderSemanticsAnnotations#b8e7c relayoutBoundary=up12
...        needs compositing
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
...        size: Size(160.0, 80.0)
...        child: RenderSemanticsAnnotations#47979 relayoutBoundary=up13
...          needs compositing
...          parentData: <none> (can use size)
...          constraints: BoxConstraints(0.0<=w<=983.0, 0.0<=h<=Infinity)
...          size: Size(160.0, 80.0)
====================================================================================================
```


## Screenshot

