### PR TITLE
スポンサーの紹介文内の URL をリンク化

### DIFF
--- a/lib/features/sponsor/ui/detail/sponsor_introduction.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_introduction.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:confwebsite2023/core/theme.dart';
 import 'package:confwebsite2023/features/sponsor/ui/detail/sponsor_detail_logo_card.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:url_launcher/link.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 final class SponsorIntroduction extends StatelessWidget {
   const SponsorIntroduction({
@@ -23,7 +27,8 @@ final class SponsorIntroduction extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
 
     return Column(
       children: [
@@ -68,9 +73,15 @@ final class SponsorIntroduction extends StatelessWidget {
                   ),
                 ),
                 Spaces.vertical_16,
-                Text(
-                  introduction,
+                Linkify(
+                  text: introduction,
+                  onOpen: (link) async => launchUrl(Uri.parse(link.url)),
+                  options: const LinkifyOptions(humanize: false),
                   style: textTheme.bodyLarge,
+                  linkStyle: textTheme.bodyLarge?.copyWith(
+                    color: theme.colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  ),
                 ),
               ],
             ),

--- a/lib/features/sponsor/ui/detail/sponsor_introduction.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_introduction.dart
@@ -73,16 +73,17 @@ final class SponsorIntroduction extends StatelessWidget {
                   ),
                 ),
                 Spaces.vertical_16,
-                Linkify(
-                  text: introduction,
-                  onOpen: (link) async => launchUrl(Uri.parse(link.url)),
-                  options: const LinkifyOptions(humanize: false),
-                  style: textTheme.bodyLarge,
-                  linkStyle: textTheme.bodyLarge?.copyWith(
-                    color: theme.colorScheme.primary,
-                    decoration: TextDecoration.underline,
+                if (introduction.isNotEmpty)
+                  Linkify(
+                    text: introduction,
+                    onOpen: (link) async => launchUrl(Uri.parse(link.url)),
+                    options: const LinkifyOptions(humanize: false),
+                    style: textTheme.bodyLarge,
+                    linkStyle: textTheme.bodyLarge?.copyWith(
+                      color: theme.colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                    ),
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/features/sponsor/ui/detail/sponsor_introduction.dart
+++ b/lib/features/sponsor/ui/detail/sponsor_introduction.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:confwebsite2023/core/theme.dart';
 import 'package:confwebsite2023/features/sponsor/ui/detail/sponsor_detail_logo_card.dart';
 import 'package:flutter/material.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,6 +318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.18.6"
+  flutter_linkify:
+    dependency: "direct main"
+    description:
+      name: flutter_linkify
+      sha256: "74669e06a8f358fee4512b4320c0b80e51cffc496607931de68d28f099254073"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -493,6 +501,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
+  linkify:
+    dependency: transitive
+    description:
+      name: linkify
+      sha256: "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   flutter_dotenv: ^5.0.2
   flutter_hooks: ^0.18.6
+  flutter_linkify: ^6.0.0
   flutter_localizations:
     sdk: flutter
   flutter_svg: ^2.0.7


### PR DESCRIPTION
## Issue

- [スポンサーセクション（第2段階）の設計・実装 · Issue #164 · FlutterKaigi/TasksBoard](https://github.com/FlutterKaigi/TasksBoard/issues/164)

## Overview (Required)

スポンサーの紹介文内の URL をリンク化します。

- flutter_linkify の導入
- スポンサーの紹介文内の URL をリンク化
- スポンサーの紹介文があるときのみ Widget を描画するよう変更

## Link

- [flutter_linkify | Flutter Package](https://pub.dev/packages/flutter_linkify)
