### PR TITLE
MarkdownBody のスタイルを調整

### DIFF
--- a/lib/features/session/ui/detail/session_detail_content.dart
+++ b/lib/features/session/ui/detail/session_detail_content.dart
@@ -110,6 +110,11 @@ class SessionDetailContent extends StatelessWidget {
       ],
     );
 
+    final hPadding = EdgeInsets.only(
+      top: contentGap,
+      bottom: contentGap / 2,
+    );
+
     final body = DecoratedBox(
       decoration: BoxDecoration(
         color: Colors.black.withOpacity(0.35),
@@ -163,9 +168,19 @@ class SessionDetailContent extends StatelessWidget {
             profileBody,
             contentVerticalGap,
             Divider(color: baselineColorScheme.ref.secondary.secondary50),
-            contentVerticalGap,
             MarkdownBody(
               data: session.abstract,
+              styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
+                p: textTheme.bodyLarge,
+                pPadding: const EdgeInsets.symmetric(vertical: 8),
+                h1: textTheme.headlineLarge,
+                h1Padding: hPadding,
+                h2: textTheme.headlineMedium,
+                h2Padding: hPadding,
+                h3: textTheme.headlineSmall,
+                h3Padding: hPadding,
+                blockSpacing: 8,
+              ),
               softLineBreak: true,
             ),
           ],


### PR DESCRIPTION
## Issue

- https://github.com/FlutterKaigi/TasksBoard/issues/166

## Overview (Required)

MarkdownBody のスタイルを調整します。
全体的に余白を取ることにより、文字を読みやすくする狙いです。

## Screenshot

### Before

![Before](https://github.com/FlutterKaigi/2023/assets/19267812/9755f4da-f886-44ae-adfa-5f1f46746653)

### After

![After](https://github.com/FlutterKaigi/2023/assets/19267812/58dd0928-dea4-41fd-a5d2-c3ee4e3fbd52)
