### PR TITLE
Add Flutter sponsorship description

### DIFF
--- a/lib/features/sponsor/data/sponsor_data_source.dart
+++ b/lib/features/sponsor/data/sponsor_data_source.dart
@@ -94,6 +94,9 @@ List<Sponsor> _goldSponsors(_GoldSponsorsRef ref) => [
         logoAssetName: Assets.sponsors.flutter,
         plan: SponsorPlan.gold,
         session: null,
+        introduction: '''
+Flutter is an open source framework by Google for building beautiful, natively compiled, multi-platform applications. Transform your app development process to launch faster with less resources by building, testing, and deploying from a single codebase.
+'''
       ),
       Sponsor(
         name: 'magicpod',


### PR DESCRIPTION
This PR adds a missing sponsorship description for a Gold Sponsor - Flutter.

## Screenshot

<img src="https://github.com/FlutterKaigi/2023/assets/208494/26c8aab6-10b9-4685-9375-cb95392a0636" width="300px" />
