### PR TITLE
11/10以降の開催終了後の設計・実装

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:confwebsite2023/app/router/router.dart';
+import 'package:confwebsite2023/core/components/finish_snack_bar.dart';
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/theme.dart';
 import 'package:confwebsite2023/features/access/ui/access_widget.dart';
@@ -151,7 +152,14 @@ class _MainPageBody extends StatelessWidget {
           controller: scrollController,
           slivers: [
             const SliverToBoxAdapter(
-              child: Spaces.vertical_40,
+              child: Spaces.vertical_80,
+            ),
+            _Sliver(
+              padding: padding,
+              child: const FinishSnackBar(),
+            ),
+            const SliverToBoxAdapter(
+              child: Spaces.vertical_80,
             ),
             _Sliver(
               padding: padding,

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -5,7 +5,6 @@ import 'package:confwebsite2023/core/components/finish_snack_bar.dart';
 import 'package:confwebsite2023/core/components/responsive_widget.dart';
 import 'package:confwebsite2023/core/theme.dart';
 import 'package:confwebsite2023/features/access/ui/access_widget.dart';
-import 'package:confwebsite2023/features/announcement/ui/announcement_section.dart';
 import 'package:confwebsite2023/features/app_links/ui/app_links_section.dart';
 import 'package:confwebsite2023/features/count_down/model/count_down_timer.dart';
 import 'package:confwebsite2023/features/count_down/ui/count_down_section.dart';
@@ -34,7 +33,6 @@ class MainPage extends HookWidget {
       access: GlobalObjectKey('accessSectionKey'),
       event: GlobalObjectKey('eventSectionKey'),
       session: GlobalObjectKey('sessionSectionKey'),
-      announcement: GlobalObjectKey('announcementSectionKey'),
       sponsor: GlobalObjectKey('sponsorSectionKey'),
       staff: GlobalObjectKey('staffSectionKey'),
     );
@@ -61,10 +59,6 @@ class MainPage extends HookWidget {
       HeaderItemButtonData(
         title: 'Event',
         onPressed: () async => scrollToSection(sectionKeys.event),
-      ),
-      HeaderItemButtonData(
-        title: 'Announcement',
-        onPressed: () async => scrollToSection(sectionKeys.announcement),
       ),
       HeaderItemButtonData(
         title: 'Sponsor',
@@ -113,7 +107,6 @@ class _MainPageBody extends StatelessWidget {
     GlobalObjectKey access,
     GlobalObjectKey event,
     GlobalObjectKey session,
-    GlobalObjectKey announcement,
     GlobalObjectKey sponsor,
     GlobalObjectKey staff
   }) sectionKeys;
@@ -213,15 +206,6 @@ class _MainPageBody extends StatelessWidget {
               padding: padding,
               child: HandsOnEvent(
                 key: sectionKeys.event,
-              ),
-            ),
-            const SliverToBoxAdapter(
-              child: Spaces.vertical_200,
-            ),
-            _Sliver(
-              padding: padding,
-              child: AnnouncementSection(
-                key: sectionKeys.announcement,
               ),
             ),
             const SliverToBoxAdapter(

--- a/lib/core/components/finish_snack_bar.dart
+++ b/lib/core/components/finish_snack_bar.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class FinishSnackBar extends StatelessWidget {
+  const FinishSnackBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFE6E1E5),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          'FlutterKaigi2023は終了しました。たくさんの方にご参加いただきありがとうございました。',
+          style: textTheme.bodyMedium!.copyWith(
+            color: const Color(0xFF49454F),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/event/hands-on/ui/hands_on_event.dart
+++ b/lib/features/event/hands-on/ui/hands_on_event.dart
@@ -12,11 +12,9 @@ class HandsOnEvent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const text =
-        // ignore: lines_longer_than_80_chars
-        '今年のハンズオンは10月26日をもって終了しました。多くの皆様にご参加いただき誠にありがとうございました。FlutterKaigi本編にもご参加される方には先着15名の限定ノベルティを用意しております。ノベルティの配布は、受付とは別に会場内に設置した専用のコーナーで行いますのでご注意ください。';
+    const text = '今年のハンズオンは10月26日をもって終了しました。多くの皆様にご参加いただき誠にありがとうございました。';
     return WantedWidget(
-      title: 'Have a blast!',
+      title: 'Thanks for joining us!',
       ticketButtonTitle: 'イベント詳細ページ',
       content: text,
       ticketOnPressed: () async => launchUrlString(


### PR DESCRIPTION
## Issue

- close #255

## Overview (Required)

- [x]  hands-on-event セクションの文言を以下に変更する
今年のハンズオンは10月26日をもって終了しました。多くの皆様にご参加いただき誠にありがとうございました。
- [x]  hands-on-event セッションのタイトルの文言を以下に変更する
「Thanks for joining us!」
- [x] HomePageに「FlutterKaigi2023は終了しました。たくさんの方にご参加いただきありがとうございました。」のSnackBarを追加する
- [x]  Announcement セクションの削除


## Links

- https://flutterkaigi-2023-preview--pr215-feature-finish-11-10-guw0qdcf.web.app/

## 確認事項
- マージするのは11月10日にする