### PR TITLE
Announcement に Wi-Fi と 昼食についての情報を追加

### DIFF
--- a/lib/features/announcement/ui/announcement_section.dart
+++ b/lib/features/announcement/ui/announcement_section.dart
@@ -57,6 +57,14 @@ final class _AnnouncementList extends StatelessWidget {
           _AnnouncementItem(
             'イベントの模様は撮影される場合がございます。その場合、お客様が写り込む場合もございますので、予めご了承ください。',
           ),
+          _verticalGap,
+          _AnnouncementItem(
+            '''来場者向けの Wi-Fi の提供はございません。登壇者、スポンサー（出し物に関連した利用のみ）にのみ提供いたしますので、予めご了承ください。''',
+          ),
+          _verticalGap,
+          _AnnouncementItem(
+            '''昼食の提供はございません。会場周辺のお店をご利用ください。また、公式アプリにて会場周辺のお店を紹介しておりますので、ぜひご活用ください。''',
+          ),
         ],
       );
 }


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

Announcement に Wi-Fi と 昼食についての情報を追加しました。

文言は ↓ で調整済みです。
https://flutterkaigi.slack.com/archives/C0571SK9BK4/p1698761168105339


## Screenshot

![image](https://github.com/FlutterKaigi/2023/assets/32213113/5bb40d18-7983-41cc-94d1-f514a3727907)
