### PR TITLE
Announcement に充電スペースについての情報を追加

### DIFF
--- a/lib/features/announcement/ui/announcement_section.dart
+++ b/lib/features/announcement/ui/announcement_section.dart
@@ -67,7 +67,7 @@ final class _AnnouncementList extends StatelessWidget {
           ),
           _verticalGap,
           _AnnouncementItem(
-            '''来場者向けの充電スペースは設けません。控室とスポンサーブースには電源タップを配置いたしますので、登壇者とスポンサーは充電可能です。''',
+            '''来場者向けの充電スペースは設けません。充電が必要な方はモバイルバッテリーなどをご持参ください。''',
           ),
         ],
       );

--- a/lib/features/announcement/ui/announcement_section.dart
+++ b/lib/features/announcement/ui/announcement_section.dart
@@ -65,6 +65,10 @@ final class _AnnouncementList extends StatelessWidget {
           _AnnouncementItem(
             '''昼食の提供はございません。会場周辺のお店をご利用ください。また、公式アプリにて会場周辺のお店を紹介しておりますので、ぜひご活用ください。''',
           ),
+          _verticalGap,
+          _AnnouncementItem(
+            '''来場者向けの充電スペースは設けません。控室とスポンサーブースには電源タップを配置いたしますので、登壇者とスポンサーは充電可能です。''',
+          ),
         ],
       );
 }


### PR DESCRIPTION
## Issue

なし

## Overview (Required)

Announcement に充電スペースについての情報を追加しました。 

文言は ↓ で調整済み
https://flutterkaigi.slack.com/archives/C0571SK9BK4/p1698837273008089

## Screenshot

![image](https://github.com/FlutterKaigi/2023/assets/32213113/280b5cd9-4667-4ca7-964b-cc3587df6c6a)